### PR TITLE
Feat/be-match

### DIFF
--- a/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
@@ -9,12 +9,14 @@ import mainproject33.global.dto.MultiResponseDto;
 import mainproject33.global.dto.SingleResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.List;
 
@@ -29,7 +31,7 @@ public class MatchBoardController {
     private final MatchBoardMapper mapper;
 
     @PostMapping
-    public ResponseEntity postMatchBoard(@RequestBody MatchBoardDto.Post post) {
+    public ResponseEntity postMatchBoard(@RequestBody @Valid MatchBoardDto.Post post) {
         MatchBoard matchBoard = matchBoardService.createMatchBoard(mapper.postMatchBoardToMatchBoard(post));
 
         return new ResponseEntity(
@@ -37,8 +39,9 @@ public class MatchBoardController {
     }
 
     @PatchMapping("/{match-id}")
-    public ResponseEntity patchMatchBoard(@PathVariable("match-id") @Positive Long id,
-                                          @RequestBody MatchBoardDto.Patch patch) {
+    public ResponseEntity patchMatchBoard(@PathVariable("match-id")
+                                              @Positive(message = "id 값은 0보다 커야합니다.") Long id,
+                                          @RequestBody @Valid MatchBoardDto.Patch patch) {
         patch.setId(id);
         MatchBoard matchBoard = matchBoardService.updateMatchBoard(mapper.patchMatchBoardToMatchBoard(patch));
 
@@ -47,7 +50,8 @@ public class MatchBoardController {
     }
 
     @GetMapping("/{match-id}")
-    public ResponseEntity getMatchBoard(@PathVariable("match-id") @Positive Long id) {
+    public ResponseEntity getMatchBoard(@PathVariable("match-id")
+                                            @Positive(message = "id 값은 0보다 커야합니다.") Long id) {
         MatchBoard matchBoard = matchBoardService.readMatchBoard(id);
 
         return new ResponseEntity(
@@ -56,7 +60,8 @@ public class MatchBoardController {
 
     @GetMapping
     public ResponseEntity getMatchBoards(@RequestParam(value = "keyword", required = false) String keyword,
-                                         @PageableDefault Pageable pageable) {
+                                         @PageableDefault(sort = "id", direction = Sort.Direction.DESC)
+                                         Pageable pageable) {
         Page<MatchBoard> matchBoardPage = matchBoardService.readMatchBoards(keyword, pageable.previousOrFirst());
         List<MatchBoard> matchBoards = matchBoardPage.getContent();
 
@@ -67,7 +72,8 @@ public class MatchBoardController {
     }
 
     @DeleteMapping("/{match-id}")
-    public ResponseEntity deleteMatchBoard(@PathVariable("match-id") @Positive Long id) {
+    public ResponseEntity deleteMatchBoard(@PathVariable("match-id")
+                                               @Positive(message = "id 값은 0보다 커야합니다.") Long id) {
         matchBoardService.deleteMatchBoard(id);
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);

--- a/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
@@ -1,0 +1,75 @@
+package mainproject33.domain.matchboard.controller;
+
+import lombok.RequiredArgsConstructor;
+import mainproject33.domain.matchboard.dto.MatchBoardDto;
+import mainproject33.domain.matchboard.entity.MatchBoard;
+import mainproject33.domain.matchboard.mapper.MatchBoardMapper;
+import mainproject33.domain.matchboard.service.MatchBoardService;
+import mainproject33.global.dto.MultiResponseDto;
+import mainproject33.global.dto.SingleResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+@Validated
+public class MatchBoardController {
+    // TODO : member entity 연계 시, memberId, memberNickname 정상적으로 받아올 수 있어야 함
+
+    private final MatchBoardService matchBoardService;
+    private final MatchBoardMapper mapper;
+
+    @PostMapping
+    public ResponseEntity postMatchBoard(@RequestBody MatchBoardDto.Post post) {
+        MatchBoard matchBoard = matchBoardService.createMatchBoard(mapper.postMatchBoardToMatchBoard(post));
+
+        return new ResponseEntity(
+                new SingleResponseDto<>(mapper.matchBoardToMatchBoardResponse(matchBoard)), HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{match-id}")
+    public ResponseEntity patchMatchBoard(@PathVariable("match-id") @Positive Long id,
+                                          @RequestBody MatchBoardDto.Patch patch) {
+        patch.setId(id);
+        MatchBoard matchBoard = matchBoardService.updateMatchBoard(mapper.patchMatchBoardToMatchBoard(patch));
+
+        return new ResponseEntity(
+                new SingleResponseDto<>(mapper.matchBoardToMatchBoardResponse(matchBoard)), HttpStatus.OK);
+    }
+
+    @GetMapping("/{match-id}")
+    public ResponseEntity getMatchBoard(@PathVariable("match-id") @Positive Long id) {
+        MatchBoard matchBoard = matchBoardService.readMatchBoard(id);
+
+        return new ResponseEntity(
+                new SingleResponseDto<>(mapper.matchBoardToMatchBoardResponse(matchBoard)), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity getMatchBoards(@RequestParam(value = "keyword", required = false) String keyword,
+                                         @PageableDefault Pageable pageable) {
+        Page<MatchBoard> matchBoardPage = matchBoardService.readMatchBoards(keyword, pageable.previousOrFirst());
+        List<MatchBoard> matchBoards = matchBoardPage.getContent();
+
+        return new ResponseEntity(
+                new MultiResponseDto<>(
+                        mapper.matchBoardsToMatchBoardResponses(matchBoards), matchBoardPage),
+                HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{match-id}")
+    public ResponseEntity deleteMatchBoard(@PathVariable("match-id") @Positive Long id) {
+        matchBoardService.deleteMatchBoard(id);
+
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
@@ -60,7 +60,7 @@ public class MatchBoardController {
 
     @GetMapping
     public ResponseEntity getMatchBoards(@RequestParam(value = "keyword", required = false) String keyword,
-                                         @PageableDefault(sort = "id", direction = Sort.Direction.DESC)
+                                         @PageableDefault(size = 8, sort = "id", direction = Sort.Direction.DESC)
                                          Pageable pageable) {
         Page<MatchBoard> matchBoardPage = matchBoardService.readMatchBoards(keyword, pageable.previousOrFirst());
         List<MatchBoard> matchBoards = matchBoardPage.getContent();

--- a/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
@@ -1,0 +1,36 @@
+package mainproject33.domain.matchboard.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+public class MatchBoardDto {
+
+    @Getter
+    @Setter
+    public static class Post {
+        private String title;
+        private String content;
+    }
+
+    @Getter
+    @Setter
+    public static class Patch {
+        private long id;
+        private String title;
+        private String content;
+    }
+
+    @Getter
+    @Setter
+    public static class Response {
+        private long memberId;
+        private String nickname;
+        private long id;
+        private String title;
+        private String content;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
+    }
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
@@ -2,11 +2,13 @@ package mainproject33.domain.matchboard.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import mainproject33.domain.gamedb.entity.GameDB;
 import mainproject33.domain.matchboard.utils.validator.Tags;
 import org.hibernate.validator.constraints.Length;
-import org.springframework.lang.Nullable;
 
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.LinkedList;
@@ -24,8 +26,13 @@ public class MatchBoardDto {
         @NotBlank(message  = "내용은 필수 입력 값입니다.")
         @Length(max = 500, message = "내용은  최대 500자 까지 입력 가능합니다.")
         private String content;
+        @NotBlank(message  = "게임은 필수 입력 값입니다.")
+        private String game;
+        @NotNull(message  = "팀원 수는 필수 입력 값입니다.")
+        @Max(20)
+        private int team;
         @Tags
-        @Size(max = 5)
+        @Size(max = 3)
         private List<String> tags = new LinkedList<>();
     }
 
@@ -37,8 +44,11 @@ public class MatchBoardDto {
         private String title;
         @Length(max = 500, message = "내용은  최대 500자 까지 입력 가능합니다.")
         private String content;
+        private String game;
+        @Max(20)
+        private int team;
         @Tags
-        @Size(max = 5)
+        @Size(max = 3)
         private List<String> tags = new LinkedList<>();
     }
 
@@ -50,6 +60,8 @@ public class MatchBoardDto {
         private long id;
         private String title;
         private String content;
+        private GameDB game;
+        private int team;
         private List<String> tags;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;

--- a/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
@@ -2,10 +2,15 @@ package mainproject33.domain.matchboard.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import mainproject33.domain.matchboard.utils.validator.Tags;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
+import java.util.LinkedList;
+import java.util.List;
 
 public class MatchBoardDto {
 
@@ -19,18 +24,22 @@ public class MatchBoardDto {
         @NotBlank(message  = "내용은 필수 입력 값입니다.")
         @Length(max = 500, message = "내용은  최대 500자 까지 입력 가능합니다.")
         private String content;
+        @Tags
+        @Size(max = 5)
+        private List<String> tags = new LinkedList<>();
     }
 
     @Getter
     @Setter
     public static class Patch {
         private long id;
-        @NotBlank(message  = "제목은 필수 입력 값입니다.")
         @Length(max = 30, message = "제목은 최대 30자 까지 입력 가능합니다.")
         private String title;
-        @NotBlank(message  = "내용은 필수 입력 값입니다.")
         @Length(max = 500, message = "내용은  최대 500자 까지 입력 가능합니다.")
         private String content;
+        @Tags
+        @Size(max = 5)
+        private List<String> tags = new LinkedList<>();
     }
 
     @Getter
@@ -41,6 +50,7 @@ public class MatchBoardDto {
         private long id;
         private String title;
         private String content;
+        private List<String> tags;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
     }

--- a/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/dto/MatchBoardDto.java
@@ -2,7 +2,9 @@ package mainproject33.domain.matchboard.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
+import javax.validation.constraints.NotBlank;
 import java.time.LocalDateTime;
 
 public class MatchBoardDto {
@@ -10,7 +12,12 @@ public class MatchBoardDto {
     @Getter
     @Setter
     public static class Post {
+
+        @NotBlank(message  = "제목은 필수 입력 값입니다.")
+        @Length(max = 30, message = "제목은 최대 30자 까지 입력 가능합니다.")
         private String title;
+        @NotBlank(message  = "내용은 필수 입력 값입니다.")
+        @Length(max = 500, message = "내용은  최대 500자 까지 입력 가능합니다.")
         private String content;
     }
 
@@ -18,7 +25,11 @@ public class MatchBoardDto {
     @Setter
     public static class Patch {
         private long id;
+        @NotBlank(message  = "제목은 필수 입력 값입니다.")
+        @Length(max = 30, message = "제목은 최대 30자 까지 입력 가능합니다.")
         private String title;
+        @NotBlank(message  = "내용은 필수 입력 값입니다.")
+        @Length(max = 500, message = "내용은  최대 500자 까지 입력 가능합니다.")
         private String content;
     }
 

--- a/server/src/main/java/mainproject33/domain/matchboard/entity/MatchBoard.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/entity/MatchBoard.java
@@ -2,10 +2,14 @@ package mainproject33.domain.matchboard.entity;
 
 import lombok.Getter;
 import lombok.Setter;
+import mainproject33.domain.matchboard.utils.validator.Tags;
 import mainproject33.domain.member.entity.Member;
 import mainproject33.global.audit.Auditable;
 
 import javax.persistence.*;
+import javax.validation.constraints.Null;
+import java.util.LinkedList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -15,9 +19,14 @@ public class MatchBoard extends Auditable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
+    @Column(length = 30, nullable = false)
     private String title;
 
+    @Column(length = 500, nullable = false)
     private String content;
+
+    @ElementCollection(fetch = FetchType.LAZY)
+    private List<String> tags = new LinkedList<>();
 
     @ManyToOne
     @JoinColumn(name = "member_id")

--- a/server/src/main/java/mainproject33/domain/matchboard/entity/MatchBoard.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/entity/MatchBoard.java
@@ -2,12 +2,11 @@ package mainproject33.domain.matchboard.entity;
 
 import lombok.Getter;
 import lombok.Setter;
-import mainproject33.domain.matchboard.utils.validator.Tags;
+import mainproject33.domain.gamedb.entity.GameDB;
 import mainproject33.domain.member.entity.Member;
 import mainproject33.global.audit.Auditable;
 
 import javax.persistence.*;
-import javax.validation.constraints.Null;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -24,6 +23,13 @@ public class MatchBoard extends Auditable {
 
     @Column(length = 500, nullable = false)
     private String content;
+
+    @OneToOne
+    @JoinColumn(name = "game_id")
+    private GameDB game;
+
+    @Column
+    private int team;
 
     @ElementCollection(fetch = FetchType.LAZY)
     private List<String> tags = new LinkedList<>();

--- a/server/src/main/java/mainproject33/domain/matchboard/entity/MatchBoard.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/entity/MatchBoard.java
@@ -1,0 +1,25 @@
+package mainproject33.domain.matchboard.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+import mainproject33.domain.member.entity.Member;
+import mainproject33.global.audit.Auditable;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Setter
+public class MatchBoard extends Auditable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/mapper/MatchBoardMapper.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/mapper/MatchBoardMapper.java
@@ -1,0 +1,86 @@
+package mainproject33.domain.matchboard.mapper;
+
+import mainproject33.domain.matchboard.dto.MatchBoardDto;
+import mainproject33.domain.matchboard.entity.MatchBoard;
+import mainproject33.domain.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MatchBoardMapper {
+
+    public MatchBoard postMatchBoardToMatchBoard(MatchBoardDto.Post post) {
+        if (post == null) return null;
+
+        MatchBoard matchBoard = new MatchBoard();
+
+        matchBoard.setTitle(post.getTitle());
+        matchBoard.setContent(post.getContent());
+
+        return matchBoard;
+    }
+
+    public MatchBoard patchMatchBoardToMatchBoard(MatchBoardDto.Patch patch) {
+        if (patch == null) return null;
+
+        MatchBoard matchBoard = new MatchBoard();
+
+        matchBoard.setId(patch.getId());
+        matchBoard.setTitle(patch.getTitle());
+        matchBoard.setContent(patch.getContent());
+
+        return matchBoard;
+    }
+
+    public MatchBoardDto.Response matchBoardToMatchBoardResponse(MatchBoard matchBoard) {
+        if (matchBoard == null) return null;
+
+        MatchBoardDto.Response response = new MatchBoardDto.Response();
+
+        response.setMemberId(matchBoardMemberId(matchBoard));
+        response.setNickname(matchBoardNickname(matchBoard));
+        response.setId(matchBoard.getId());
+        response.setTitle(matchBoard.getTitle());
+        response.setContent(matchBoard.getContent());
+        response.setCreatedAt(matchBoard.getCreatedAt());
+        response.setModifiedAt(matchBoard.getModifiedAt());
+
+        return response;
+    }
+
+    public List<MatchBoardDto.Response> matchBoardsToMatchBoardResponses(List<MatchBoard> matchBoards) {
+        if (matchBoards == null) return null;
+
+        List<MatchBoardDto.Response> responses = new ArrayList<>(matchBoards.size());
+
+        for (MatchBoard board : matchBoards) {
+            responses.add(matchBoardToMatchBoardResponse(board));
+        }
+
+        return responses;
+    }
+
+    private long matchBoardMemberId(MatchBoard matchBoard) {
+        if (matchBoard == null) return 0L;
+
+        Member member = matchBoard.getMember();
+        if ( member == null ) {
+            return 0L;
+        }
+        long id = member.getId();
+        return id;
+    }
+
+    private String matchBoardNickname(MatchBoard matchBoard) {
+        if (matchBoard == null) return null;
+
+        Member member = matchBoard.getMember();
+        if ( member == null ) {
+            return null;
+        }
+        String nickname = member.getNickname();
+        return nickname;
+    }
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/mapper/MatchBoardMapper.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/mapper/MatchBoardMapper.java
@@ -1,5 +1,8 @@
 package mainproject33.domain.matchboard.mapper;
 
+import lombok.RequiredArgsConstructor;
+import mainproject33.domain.gamedb.entity.GameDB;
+import mainproject33.domain.gamedb.repository.GameDBRepository;
 import mainproject33.domain.matchboard.dto.MatchBoardDto;
 import mainproject33.domain.matchboard.entity.MatchBoard;
 import mainproject33.domain.member.entity.Member;
@@ -9,7 +12,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Component
+@RequiredArgsConstructor
 public class MatchBoardMapper {
+
+    private final GameDBRepository gameDBRepository;
 
     public MatchBoard postMatchBoardToMatchBoard(MatchBoardDto.Post post) {
         if (post == null) return null;
@@ -18,6 +24,11 @@ public class MatchBoardMapper {
 
         matchBoard.setTitle(post.getTitle());
         matchBoard.setContent(post.getContent());
+
+        GameDB game = gameDBRepository.findByKorTitle(post.getGame());
+        matchBoard.setGame(game);
+
+        matchBoard.setTeam(post.getTeam());
         matchBoard.setTags(post.getTags());
 
         return matchBoard;
@@ -31,6 +42,11 @@ public class MatchBoardMapper {
         matchBoard.setId(patch.getId());
         matchBoard.setTitle(patch.getTitle());
         matchBoard.setContent(patch.getContent());
+
+        GameDB game = gameDBRepository.findByKorTitle(patch.getGame());
+        matchBoard.setGame(game);
+
+        matchBoard.setTeam(patch.getTeam());
         matchBoard.setTags(patch.getTags());
 
         return matchBoard;
@@ -46,6 +62,8 @@ public class MatchBoardMapper {
         response.setId(matchBoard.getId());
         response.setTitle(matchBoard.getTitle());
         response.setContent(matchBoard.getContent());
+        response.setGame(matchBoard.getGame());
+        response.setTeam(matchBoard.getTeam());
         response.setTags(matchBoard.getTags());
         response.setCreatedAt(matchBoard.getCreatedAt());
         response.setModifiedAt(matchBoard.getModifiedAt());

--- a/server/src/main/java/mainproject33/domain/matchboard/mapper/MatchBoardMapper.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/mapper/MatchBoardMapper.java
@@ -18,6 +18,7 @@ public class MatchBoardMapper {
 
         matchBoard.setTitle(post.getTitle());
         matchBoard.setContent(post.getContent());
+        matchBoard.setTags(post.getTags());
 
         return matchBoard;
     }
@@ -30,6 +31,7 @@ public class MatchBoardMapper {
         matchBoard.setId(patch.getId());
         matchBoard.setTitle(patch.getTitle());
         matchBoard.setContent(patch.getContent());
+        matchBoard.setTags(patch.getTags());
 
         return matchBoard;
     }
@@ -44,6 +46,7 @@ public class MatchBoardMapper {
         response.setId(matchBoard.getId());
         response.setTitle(matchBoard.getTitle());
         response.setContent(matchBoard.getContent());
+        response.setTags(matchBoard.getTags());
         response.setCreatedAt(matchBoard.getCreatedAt());
         response.setModifiedAt(matchBoard.getModifiedAt());
 

--- a/server/src/main/java/mainproject33/domain/matchboard/repository/MatchBoardRepository.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/repository/MatchBoardRepository.java
@@ -1,0 +1,13 @@
+package mainproject33.domain.matchboard.repository;
+
+import mainproject33.domain.matchboard.entity.MatchBoard;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MatchBoardRepository extends JpaRepository<MatchBoard, Long> {
+    @Query(value = "select * from MATCH_BOARD where title like %:keyword% or content like %:keyword%", nativeQuery = true)
+    Page<MatchBoard> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
@@ -22,6 +22,8 @@ public class MatchBoardService {
 
         createdMatchBoard.setTitle(matchBoard.getTitle());
         createdMatchBoard.setContent(matchBoard.getContent());
+        createdMatchBoard.setGame(matchBoard.getGame()); // TODO : Game DB에 있는 객체를 가지고 와서 저장 (mapper 에서 처리)
+        createdMatchBoard.setTeam(matchBoard.getTeam());
         Optional.ofNullable(matchBoard.getTags())
                 .ifPresent(tags -> createdMatchBoard.setTags(tags));
 
@@ -39,6 +41,9 @@ public class MatchBoardService {
                 .ifPresent(content -> findMatchBoard.setContent(content));
         Optional.ofNullable(matchBoard.getTags())
                 .ifPresent(tags -> findMatchBoard.setTags(tags));
+        Optional.ofNullable(matchBoard.getGame())
+                .ifPresent(game -> findMatchBoard.setGame(game));
+        if (matchBoard.getTeam() != 0) findMatchBoard.setTeam(matchBoard.getTeam());
 
         return matchBoardRepository.save(findMatchBoard);
     }

--- a/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
@@ -1,0 +1,67 @@
+package mainproject33.domain.matchboard.service;
+
+import lombok.RequiredArgsConstructor;
+import mainproject33.domain.matchboard.entity.MatchBoard;
+import mainproject33.domain.matchboard.repository.MatchBoardRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchBoardService {
+
+    private final MatchBoardRepository matchBoardRepository;
+
+    public MatchBoard createMatchBoard(MatchBoard matchBoard) {
+        MatchBoard createdMatchBoard = new MatchBoard();
+        createdMatchBoard.setTitle(matchBoard.getTitle());
+        createdMatchBoard.setContent(matchBoard.getContent());
+
+        // set createdAt, modifiedAt
+        createdMatchBoard.setCreatedAt(LocalDateTime.now());
+        createdMatchBoard.setModifiedAt(LocalDateTime.now());
+
+        return matchBoardRepository.save(createdMatchBoard);
+    }
+
+    public MatchBoard updateMatchBoard(MatchBoard matchBoard) {
+        MatchBoard findMatchBoard = matchBoardRepository.findById(matchBoard.getId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 매칭 게시글 입니다.")); // TODO : 구체적인 Exception Handling 추후 필요.
+
+        Optional.ofNullable(matchBoard.getTitle())
+                .ifPresent(title -> findMatchBoard.setTitle(title));
+        Optional.ofNullable(matchBoard.getContent())
+                .ifPresent(content -> findMatchBoard.setContent(content));
+
+        // set modifiedAt
+        findMatchBoard.setModifiedAt(LocalDateTime.now());
+
+        return matchBoardRepository.save(findMatchBoard);
+    }
+
+    public MatchBoard readMatchBoard(long id) {
+        MatchBoard findMatchBoard = matchBoardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 매칭 게시글 입니다.")); // TODO : 구체적인 Exception Handling 추후 필요.
+
+        return findMatchBoard;
+    }
+
+    public Page<MatchBoard> readMatchBoards(String keyword, Pageable pageable) {
+        if (keyword == null) {
+            return matchBoardRepository.findAll(pageable);
+        } else {
+            return matchBoardRepository.findByKeyword(keyword, pageable);
+        }
+    }
+
+    public void deleteMatchBoard(long id) {
+        MatchBoard findMatchBoard = matchBoardRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 매칭 게시글 입니다.")); // TODO : 구체적인 Exception Handling 추후 필요.
+
+        matchBoardRepository.delete(findMatchBoard);
+    }
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -20,8 +19,11 @@ public class MatchBoardService {
 
     public MatchBoard createMatchBoard(MatchBoard matchBoard) {
         MatchBoard createdMatchBoard = new MatchBoard();
+
         createdMatchBoard.setTitle(matchBoard.getTitle());
         createdMatchBoard.setContent(matchBoard.getContent());
+        Optional.ofNullable(matchBoard.getTags())
+                .ifPresent(tags -> createdMatchBoard.setTags(tags));
 
         return matchBoardRepository.save(createdMatchBoard);
     }
@@ -35,6 +37,8 @@ public class MatchBoardService {
                 .ifPresent(title -> findMatchBoard.setTitle(title));
         Optional.ofNullable(matchBoard.getContent())
                 .ifPresent(content -> findMatchBoard.setContent(content));
+        Optional.ofNullable(matchBoard.getTags())
+                .ifPresent(tags -> findMatchBoard.setTags(tags));
 
         return matchBoardRepository.save(findMatchBoard);
     }

--- a/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
@@ -3,11 +3,13 @@ package mainproject33.domain.matchboard.service;
 import lombok.RequiredArgsConstructor;
 import mainproject33.domain.matchboard.entity.MatchBoard;
 import mainproject33.domain.matchboard.repository.MatchBoardRepository;
+import mainproject33.global.exception.ExceptionMessage;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
@@ -30,7 +32,8 @@ public class MatchBoardService {
 
     public MatchBoard updateMatchBoard(MatchBoard matchBoard) {
         MatchBoard findMatchBoard = matchBoardRepository.findById(matchBoard.getId())
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 매칭 게시글 입니다.")); // TODO : 구체적인 Exception Handling 추후 필요.
+                .orElseThrow(()
+                        -> new NoSuchElementException(ExceptionMessage.MATCH_BOARD_NOT_FOUND.get()));
 
         Optional.ofNullable(matchBoard.getTitle())
                 .ifPresent(title -> findMatchBoard.setTitle(title));
@@ -45,7 +48,8 @@ public class MatchBoardService {
 
     public MatchBoard readMatchBoard(long id) {
         MatchBoard findMatchBoard = matchBoardRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 매칭 게시글 입니다.")); // TODO : 구체적인 Exception Handling 추후 필요.
+                .orElseThrow(()
+                        -> new NoSuchElementException(ExceptionMessage.MATCH_BOARD_NOT_FOUND.get()));
 
         return findMatchBoard;
     }
@@ -60,7 +64,8 @@ public class MatchBoardService {
 
     public void deleteMatchBoard(long id) {
         MatchBoard findMatchBoard = matchBoardRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 매칭 게시글 입니다.")); // TODO : 구체적인 Exception Handling 추후 필요.
+                .orElseThrow(()
+                        -> new NoSuchElementException(ExceptionMessage.MATCH_BOARD_NOT_FOUND.get()));
 
         matchBoardRepository.delete(findMatchBoard);
     }

--- a/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
@@ -23,10 +23,6 @@ public class MatchBoardService {
         createdMatchBoard.setTitle(matchBoard.getTitle());
         createdMatchBoard.setContent(matchBoard.getContent());
 
-        // set createdAt, modifiedAt
-        createdMatchBoard.setCreatedAt(LocalDateTime.now());
-        createdMatchBoard.setModifiedAt(LocalDateTime.now());
-
         return matchBoardRepository.save(createdMatchBoard);
     }
 
@@ -39,9 +35,6 @@ public class MatchBoardService {
                 .ifPresent(title -> findMatchBoard.setTitle(title));
         Optional.ofNullable(matchBoard.getContent())
                 .ifPresent(content -> findMatchBoard.setContent(content));
-
-        // set modifiedAt
-        findMatchBoard.setModifiedAt(LocalDateTime.now());
 
         return matchBoardRepository.save(findMatchBoard);
     }

--- a/server/src/main/java/mainproject33/domain/matchboard/utils/validator/Tags.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/utils/validator/Tags.java
@@ -1,0 +1,17 @@
+package mainproject33.domain.matchboard.utils.validator;
+
+import javax.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = TagsValidator.class)
+public @interface Tags {
+
+    String message() default "태그는 띄어쓰기 없이 영문 소문자 15자 이하, 한글 6자 이하로 이루어져 있어야 합니다.";
+    Class[] groups() default {};
+    Class[] payload() default {};
+}

--- a/server/src/main/java/mainproject33/domain/matchboard/utils/validator/TagsValidator.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/utils/validator/TagsValidator.java
@@ -1,0 +1,16 @@
+package mainproject33.domain.matchboard.utils.validator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+
+public class TagsValidator implements ConstraintValidator<Tags, List<String>> {
+    @Override
+    public boolean isValid(List<String> value, ConstraintValidatorContext context) {
+
+        for (String s : value) {
+            if (!s.matches("#[a-z]{1,15}|#[가-힣]{1,6}")) return false;
+        }
+        return true;
+    }
+}

--- a/server/src/main/java/mainproject33/global/audit/Auditable.java
+++ b/server/src/main/java/mainproject33/global/audit/Auditable.java
@@ -1,6 +1,7 @@
 package mainproject33.global.audit;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +12,7 @@ import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class Auditable

--- a/server/src/main/java/mainproject33/global/exception/ErrorResponse.java
+++ b/server/src/main/java/mainproject33/global/exception/ErrorResponse.java
@@ -1,0 +1,80 @@
+package mainproject33.global.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private final int status;
+    private final String message;
+    private List<ValueError> valueErrors;
+
+    private ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    private ErrorResponse(final List<ValueError> valueErrors) {
+        this.status = HttpStatus.BAD_REQUEST.value();
+        this.message = HttpStatus.BAD_REQUEST.getReasonPhrase();
+        this.valueErrors = valueErrors;
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus) {
+        return new ErrorResponse(httpStatus.value(), httpStatus.getReasonPhrase());
+    }
+
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return new ErrorResponse(httpStatus.value(), message);
+    }
+
+    public static ErrorResponse of(BindingResult bindingResult) {
+        return new ErrorResponse(ValueError.of(bindingResult));
+    }
+
+    public static ErrorResponse of(ConstraintViolationException e) {
+        return new ErrorResponse(ValueError.of(e));
+    }
+
+    @Getter
+    public static class ValueError {
+        private final String descriptor;
+        private final Object rejectedValue;
+        private final String reason;
+
+        private ValueError(String descriptor, Object rejectedValue, String reason) {
+            this.descriptor = descriptor;
+            this.rejectedValue = rejectedValue;
+            this.reason = reason;
+        }
+
+        public static List<ValueError> of(BindingResult bindingResult) {
+            return bindingResult.getFieldErrors()
+                    .stream()
+                    .map(error -> new ValueError(
+                            error.getField(),
+                            error.getRejectedValue() == null ?
+                                    "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+
+        public static List<ValueError> of(ConstraintViolationException e) {
+            return e.getConstraintViolations()
+                    .stream()
+                    .map(error -> new ValueError(
+                            error.getPropertyPath().toString(),
+                            error.getInvalidValue().toString(),
+                            error.getMessage()))
+                    .collect(Collectors.toList());
+        }
+    }
+}

--- a/server/src/main/java/mainproject33/global/exception/ExceptionAdvice.java
+++ b/server/src/main/java/mainproject33/global/exception/ExceptionAdvice.java
@@ -1,0 +1,92 @@
+package mainproject33.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import javax.validation.ConstraintViolationException;
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RestControllerAdvice
+public class ExceptionAdvice {
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("컨트롤러 메서드 인자가 올바르지 않습니다.", e);
+
+        return ErrorResponse.of(e.getBindingResult());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMethod(MethodArgumentTypeMismatchException e) {
+        log.error("컨트롤러 메서드 인자의 타입이 맞지 않습니다.", e);
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleConstraintViolationException(ConstraintViolationException e) {
+        log.error("검증 대상 객체가 제약을 위반했습니다.", e);
+
+        return ErrorResponse.of(e);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
+    public ErrorResponse handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("지원하지 않는 HTTP 메서드입니다.", e);
+
+        return ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.error("요청에 필요한 body 가 없습니다.", e);
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, "Required request body is missing");
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
+        log.error("요청에 필요한 파라미터가 없습니다: " + e.getMessage() , e);
+
+        return ErrorResponse.of(HttpStatus.BAD_REQUEST, e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponse handleNoSuchElementException(NoSuchElementException e) {
+        log.error("요소를 찾을 수 없습니다: " + e.getMessage(), e);
+
+        return ErrorResponse.of(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ErrorResponse handleDuplicateKeyException(DuplicateKeyException e) {
+        log.error("해당 키가 중복입니다: " + e.getMessage(), e);
+
+        return ErrorResponse.of(HttpStatus.CONFLICT, e.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ErrorResponse handleException(Exception e) {
+        log.error("예외가 발생했습니다.", e);
+
+        return ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+}

--- a/server/src/main/java/mainproject33/global/exception/ExceptionMessage.java
+++ b/server/src/main/java/mainproject33/global/exception/ExceptionMessage.java
@@ -1,0 +1,15 @@
+package mainproject33.global.exception;
+
+public enum ExceptionMessage {
+    MATCH_BOARD_NOT_FOUND("존재하지 않는 매칭 게시글 입니다.");
+
+    private final String message;
+
+    ExceptionMessage(String message) {
+        this.message = message;
+    }
+
+    public String get() {
+        return message;
+    }
+}

--- a/server/src/main/java/mainproject33/global/logging/SimpleLoggingAop.java
+++ b/server/src/main/java/mainproject33/global/logging/SimpleLoggingAop.java
@@ -1,0 +1,65 @@
+package mainproject33.global.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+public class SimpleLoggingAop {
+
+    @Pointcut("execution(public * *(..))")
+    private void anyPublicOperation() {}
+
+    @Pointcut("within(mainproject33.domain.matchboard.service..*)")
+    private void inMatchBoard() {}
+
+    @Pointcut("anyPublicOperation() && inMatchBoard()")
+    private void cut() {}
+
+    @Before("cut()")
+    public void beforeParameterLogging(JoinPoint joinPoint) {
+        Method method = getMethod(joinPoint);
+        log.info("======= method name : {} =======", method.getName());
+
+        Object[] args = joinPoint.getArgs();
+        if (args.length == 0) {
+            log.info("no parameter");
+        } else {
+            for (Object arg : args) {
+                if (arg == null) {
+                    log.info("parameter is null");
+                } else {
+                    log.info("parameter type : {}", arg.getClass().getSimpleName());
+                    log.info("parameter value : {}", arg);
+                }
+            }
+        }
+    }
+
+    @AfterReturning(value = "cut()", returning = "returnObj")
+    public void afterReturnLogging(JoinPoint joinPoint, Object returnObj) {
+        Method method = getMethod(joinPoint);
+        log.info("======= method name : {} =======", method.getName());
+
+        if (returnObj == null) {
+            log.info("return object is null");
+        } else {
+            log.info("return type : {}", returnObj.getClass().getSimpleName());
+            log.info("return value : {}", returnObj);
+        }
+    }
+
+    private Method getMethod(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        return signature.getMethod();
+    }
+}


### PR DESCRIPTION
## 작업개요
- 매치 게시글 CRUD 기능 구현

## worklog
- matchBoard Rest API 엔드포인트 생성
- matchBoard CRUD Business Logic 구현
- pagination 구현 (default : 1페이지 당 10개 / query parameter 값 조정 가능)
- matchBoard title, content read by keyword 구현 (검색어로 검색)
- 정렬 순 ASC -> DESC(최신순)
- 각 필드값 validation 설정

## trouble shooting & 어려웠던 점
- LocalDateTime이 계속 null로 전달됨 -> mapper에 set 메소드를 활용하여 해결 안됨 -> service 단에서 직접 LocalDateTime.now()를 set 해서 해결 -> @EnableJpaAuditing 주석 추가하여 깔끔하게 해결
- 검색어 검색 기능 구현 error (sqlSyntaxError) -> sql 문법 수정 후 해결 (OR 구문)
- client 단에서 전달된 path parameter를 인식 못함 -> 엔드포인트의 parameter 명과 @PathVariable의 parameter 이름을 통일해서 해결