### PR TITLE
[feat/be-userBoard] 유저 보드 CRUD 구현

### DIFF
--- a/server/src/main/java/mainproject33/Application.java
+++ b/server/src/main/java/mainproject33/Application.java
@@ -2,7 +2,9 @@ package mainproject33;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Application {
 

--- a/server/src/main/java/mainproject33/domain/userboard/controller/UserBoardController.java
+++ b/server/src/main/java/mainproject33/domain/userboard/controller/UserBoardController.java
@@ -1,0 +1,89 @@
+package mainproject33.domain.userboard.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mainproject33.domain.userboard.dto.UserBoardPatchDto;
+import mainproject33.domain.userboard.dto.UserBoardPostDto;
+import mainproject33.domain.userboard.dto.UserBoardResponseDto;
+import mainproject33.domain.userboard.entity.UserBoard;
+import mainproject33.domain.userboard.mapper.UserBoardMapper;
+import mainproject33.domain.userboard.repository.UserBoardRepository;
+import mainproject33.domain.userboard.service.UserBoardService;
+import mainproject33.global.dto.MultiResponseDto;
+import mainproject33.global.dto.SingleResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/boards")
+public class UserBoardController
+{
+    private final UserBoardService boardService;
+
+    private final UserBoardMapper mapper;
+
+    @PostMapping
+    public ResponseEntity postBoard(@Valid @RequestBody UserBoardPostDto postDto)
+    {
+        UserBoard userBoard = boardService.postUserBoard(mapper.postToUserBoard(postDto));
+
+        UserBoardResponseDto response = mapper.userBoardToResponse(userBoard);
+
+        log.info("등록 완료");
+        return new ResponseEntity(new SingleResponseDto<>(response), HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{board-id}")
+    public ResponseEntity patchBoard(@PathVariable("board-id") @Positive long boardId,
+                                     @Valid @RequestBody UserBoardPatchDto patchDto)
+    {
+        patchDto.setId(boardId);
+
+        UserBoard userBoard = boardService.postUserBoard(mapper.patchToUserBoard(patchDto));
+
+        UserBoardResponseDto response = mapper.userBoardToResponse(userBoard);
+
+        log.info("수정 완료");
+        return new ResponseEntity(new SingleResponseDto<>(response), HttpStatus.OK);
+    }
+
+    @GetMapping("/{board-id}")
+    public ResponseEntity getBoard(@PathVariable("board-id") @Positive long boardId)
+    {
+        UserBoard userBoard = boardService.findOne(boardId);
+
+        UserBoardResponseDto response = mapper.userBoardToResponse(userBoard);
+
+        log.info("글 조회 완료 = {}", boardId);
+        return new ResponseEntity(new SingleResponseDto<>(response), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity getBoards(@RequestParam @Positive int page,
+                                    @RequestParam @Positive int size)
+    {
+        Page<UserBoard> pageBoards = boardService.findAll(page - 1, size);
+        List<UserBoard> boards = pageBoards.getContent();
+        List<UserBoardResponseDto> responses = mapper.userBoardToResponses(boards);
+
+        log.info("글 전체 조회 완료");
+        return new ResponseEntity(new MultiResponseDto<>(responses, pageBoards), HttpStatus.OK);
+    }
+
+    @DeleteMapping("{board-id}")
+    public ResponseEntity deleteBoard(@PathVariable("board-id") @Positive long boardId)
+    {
+        boardService.deleteOne(boardId);
+
+        log.info("글 삭제 완료");
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    }
+}

--- a/server/src/main/java/mainproject33/domain/userboard/dto/UserBoardPatchDto.java
+++ b/server/src/main/java/mainproject33/domain/userboard/dto/UserBoardPatchDto.java
@@ -1,0 +1,14 @@
+package mainproject33.domain.userboard.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserBoardPatchDto
+{
+    private long id;
+
+    private String content;
+
+}

--- a/server/src/main/java/mainproject33/domain/userboard/dto/UserBoardPostDto.java
+++ b/server/src/main/java/mainproject33/domain/userboard/dto/UserBoardPostDto.java
@@ -1,0 +1,13 @@
+package mainproject33.domain.userboard.dto;
+
+import lombok.*;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class UserBoardPostDto
+{
+    @NotBlank
+    String content;
+
+}

--- a/server/src/main/java/mainproject33/domain/userboard/dto/UserBoardResponseDto.java
+++ b/server/src/main/java/mainproject33/domain/userboard/dto/UserBoardResponseDto.java
@@ -1,0 +1,59 @@
+package mainproject33.domain.userboard.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import mainproject33.domain.member.entity.Member;
+import mainproject33.domain.userboard.entity.UserBoard;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class UserBoardResponseDto
+{
+    private long memberId;
+
+    private String nickname;
+    private long id;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime modifiedAt;
+
+    public UserBoardResponseDto(UserBoard entity)
+    {
+        this.memberId = userBoardMemberId(entity);
+        this.nickname = userBoardNickname(entity);
+        this.id = entity.getId();
+        this.content = entity.getContent();
+        this.createdAt = entity.getCreatedAt();
+        this.modifiedAt = entity.getModifiedAt();
+    }
+
+    private long userBoardMemberId(UserBoard entity)
+    {
+        if(entity == null)
+            return 1L;
+
+        Member member = entity.getMember();
+        if(member == null)
+            return 1L;
+
+        long id = member.getId();
+        return id;
+    }
+
+    private String userBoardNickname(UserBoard entity)
+    {
+        if(entity == null)
+            return null;
+
+        Member member = entity.getMember();
+        if(member == null)
+            return "JohnDoe";
+
+        String nickname = member.getNickname();
+        return nickname;
+    }
+}

--- a/server/src/main/java/mainproject33/domain/userboard/entity/UserBoard.java
+++ b/server/src/main/java/mainproject33/domain/userboard/entity/UserBoard.java
@@ -1,0 +1,42 @@
+package mainproject33.domain.userboard.entity;
+
+import lombok.*;
+import mainproject33.domain.member.entity.Member;
+import mainproject33.global.audit.Auditable;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class UserBoard extends Auditable
+{
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @Builder
+    public UserBoard(Long id, String content)
+    {
+        this.id = id;
+        this.content = content;
+    }
+
+    public void updateContent(String content)
+    {
+        this.content = content;
+    }
+
+    //member 추가 시 자동으로 member 에도 userBoard 추가
+    /*public void addMember(Member member)
+    {
+        this.member = member;
+        member.getUserBoards().add(this);
+    }*/
+
+}

--- a/server/src/main/java/mainproject33/domain/userboard/mapper/UserBoardMapper.java
+++ b/server/src/main/java/mainproject33/domain/userboard/mapper/UserBoardMapper.java
@@ -1,0 +1,33 @@
+package mainproject33.domain.userboard.mapper;
+
+import mainproject33.domain.member.entity.Member;
+import mainproject33.domain.userboard.dto.UserBoardPatchDto;
+import mainproject33.domain.userboard.dto.UserBoardPostDto;
+import mainproject33.domain.userboard.dto.UserBoardResponseDto;
+import mainproject33.domain.userboard.entity.UserBoard;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Mapper(componentModel = "spring")
+public interface UserBoardMapper
+{
+    UserBoard postToUserBoard(UserBoardPostDto request);
+
+    UserBoard patchToUserBoard(UserBoardPatchDto request);
+
+    default UserBoardResponseDto userBoardToResponse(UserBoard entity)
+    {
+        return new UserBoardResponseDto(entity);
+    }
+
+    default List<UserBoardResponseDto> userBoardToResponses(List<UserBoard> entities)
+    {
+        List<UserBoardResponseDto> responses = entities.stream()
+                .map(entity -> userBoardToResponse(entity))
+                .collect(Collectors.toList());
+
+        return responses;
+    }
+}

--- a/server/src/main/java/mainproject33/domain/userboard/repository/UserBoardRepository.java
+++ b/server/src/main/java/mainproject33/domain/userboard/repository/UserBoardRepository.java
@@ -1,0 +1,10 @@
+package mainproject33.domain.userboard.repository;
+
+import mainproject33.domain.userboard.entity.UserBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserBoardRepository extends JpaRepository<UserBoard, Long>
+{
+}

--- a/server/src/main/java/mainproject33/domain/userboard/service/UserBoardService.java
+++ b/server/src/main/java/mainproject33/domain/userboard/service/UserBoardService.java
@@ -1,0 +1,72 @@
+package mainproject33.domain.userboard.service;
+
+import lombok.RequiredArgsConstructor;
+import mainproject33.domain.userboard.entity.UserBoard;
+import mainproject33.domain.userboard.repository.UserBoardRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class UserBoardService
+{
+    private final UserBoardRepository userBoardRepository;
+
+
+    public UserBoard postUserBoard(UserBoard request)
+    {
+        UserBoard userBoard = userBoardRepository.save(request);
+
+        return userBoard;
+    }
+
+    public UserBoard patchUserBoard(UserBoard request)
+    {
+        UserBoard findBoard = findOne(request.getId());
+
+        Optional.ofNullable(request.getContent())
+                .ifPresent(findBoard::updateContent);
+
+        return findBoard;
+    }
+
+    @Transactional(readOnly = true)
+    public UserBoard findOne(Long id)
+    {
+        Optional<UserBoard> optionalBoard = userBoardRepository.findById(id);
+
+        UserBoard findBoard = optionalBoard.orElseThrow(() -> new IllegalStateException("해당 글을 찾을 수 없습니다."));
+
+        return findBoard;
+    }
+
+    @Transactional(readOnly = true)
+    public Page<UserBoard> findAll(int page, int size)
+    {
+        return userBoardRepository.findAll(PageRequest.of(page, size, Sort.by("id").descending()));
+    }
+
+
+    public void deleteOne(Long id)
+    {
+        verifyExistBoard(id);
+
+        userBoardRepository.deleteById(id);
+    }
+
+    public void verifyExistBoard(Long id)
+    {
+        Optional<UserBoard> findBoard = userBoardRepository.findById(id);
+
+        if(findBoard.isEmpty())
+        {
+            throw new IllegalStateException("존재하지 않는 게시글입니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 작업개요
유저 보드 CRUD 기능 구현

## worklog
- userBoard Rest API 엔드포인트 생성
- userBoard CRUD BusinessLogic 구현
- Pagenation 구현 (page, size 값 조절 가능)
- 정렬 순 DESC(최신 순)
- 각 content별 validation 추가 예정

## trouble shooting & 어려웠던 점
- member 정보(ID, nickname)값이 null로 전달되어 에러 발생 -> ResponseDto에 Member 더미 데이터 생성으로 해결