### PR TITLE
Fix/be-gamedb

### DIFF
--- a/server/src/main/java/mainproject33/domain/gamedb/controller/GameDBController.java
+++ b/server/src/main/java/mainproject33/domain/gamedb/controller/GameDBController.java
@@ -21,7 +21,7 @@ public class GameDBController {
     private final GameDBService gameDBService;
 
     @GetMapping
-    public ResponseEntity getGameDBs(@RequestParam("keyword") String keyword) {
+    public ResponseEntity getGameDBs(@RequestParam(value = "keyword", required = false) String keyword) {
         List<GameDB> gameDBs = gameDBService.readGameDB(keyword);
 
         return new ResponseEntity(new SingleResponseDto<>(gameDBs), HttpStatus.OK);

--- a/server/src/main/java/mainproject33/domain/gamedb/repository/GameDBRepository.java
+++ b/server/src/main/java/mainproject33/domain/gamedb/repository/GameDBRepository.java
@@ -8,7 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface GameDBRepository extends JpaRepository<GameDB, Long> {
-    @Query(value = "select * from GAME_DB where kor_title like %:keyword% or eng_title like %:keyword%", nativeQuery = true)
+    @Query(value = "select * from GAME_DB where lower(replace(kor_title, ' ', '')) like %:keyword%" +
+            " or lower(replace(eng_title, ' ', '')) like %:keyword%", nativeQuery = true)
     List<GameDB> findByKeyword(@Param("keyword") String keyword);
     GameDB findByKorTitle(String korTitle);
 }

--- a/server/src/main/java/mainproject33/domain/gamedb/service/GameDBService.java
+++ b/server/src/main/java/mainproject33/domain/gamedb/service/GameDBService.java
@@ -26,6 +26,9 @@ public class GameDBService {
     public GameDB readRandomGameDB() {
         Random random = new Random();
         int randomInt = random.nextInt(gameDBRepository.findAll().size());
+        while (randomInt == 0) { // 0이 걸리면 0이 안 걸릴 때 까지 랜덤 뽑기
+            randomInt = random.nextInt(gameDBRepository.findAll().size());
+        }
 
         return gameDBRepository.findById((long) randomInt)
                 .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.MATCH_BOARD_ID_NOT_FOUND.get()));

--- a/server/src/main/java/mainproject33/domain/gamedb/service/GameDBService.java
+++ b/server/src/main/java/mainproject33/domain/gamedb/service/GameDBService.java
@@ -25,7 +25,7 @@ public class GameDBService {
 
     public GameDB readRandomGameDB() {
         Random random = new Random();
-        int randomInt = random.nextInt(gameDBRepository.findAll().size() + 1);
+        int randomInt = random.nextInt(gameDBRepository.findAll().size());
 
         return gameDBRepository.findById((long) randomInt)
                 .orElseThrow(() -> new NoSuchElementException(ExceptionMessage.MATCH_BOARD_ID_NOT_FOUND.get()));

--- a/server/src/main/java/mainproject33/domain/gamedb/service/GameDBService.java
+++ b/server/src/main/java/mainproject33/domain/gamedb/service/GameDBService.java
@@ -19,6 +19,7 @@ public class GameDBService {
         if (keyword == null) {
             return gameDBRepository.findAll();
         } else {
+            keyword = keyword.replaceAll(" ", "").toLowerCase(); // 띄어쓰기, 대소문자 상관없이 검색할 수 있게
             return gameDBRepository.findByKeyword(keyword);
         }
     }

--- a/server/src/main/resources/import.sql
+++ b/server/src/main/resources/import.sql
@@ -1,0 +1,17 @@
+INSERT INTO GAME_DB VALUES (1, 'League of Legends', '리그 오브 레전드');
+INSERT INTO GAME_DB VALUES (2, 'VALORANT', '발로란트');
+INSERT INTO GAME_DB VALUES (3, 'OVERWATCH 2', '오버워치 2');
+INSERT INTO GAME_DB VALUES (4, 'LostArk', '로스트아크');
+INSERT INTO GAME_DB VALUES (5, 'MapleStory', '메이플스토리');
+INSERT INTO GAME_DB VALUES (6, 'SuddenAttack', '서든어택');
+INSERT INTO GAME_DB VALUES (7, 'PUBGs BattleGround', '배틀그라운드');
+INSERT INTO GAME_DB VALUES (8, 'CYPHERS', '사이퍼즈');
+INSERT INTO GAME_DB VALUES (9, 'Minecraft', '마인크래프트');
+INSERT INTO GAME_DB VALUES (10, 'Diablo II', '디아블로 2');
+INSERT INTO GAME_DB VALUES (11, 'Diablo III', '디아블로 3');
+INSERT INTO GAME_DB VALUES (12, 'Among Us', '어몽어스');
+INSERT INTO GAME_DB VALUES (13, 'Final Fantasy XIV', '파이널 판타지 14');
+INSERT INTO GAME_DB VALUES (14, 'Eternal Return', '이터널 리턴');
+INSERT INTO GAME_DB VALUES (15, 'Steam Game', '스팀 게임');
+INSERT INTO GAME_DB VALUES (16, 'Nintendo Game', '닌텐도 게임');
+INSERT INTO GAME_DB VALUES (17, 'ETC', '기타');


### PR DESCRIPTION
## 작업개요
- GameDB 관련 버그 픽스

## worklog
- GameDB -> case / space insensitive 검색 구현 (기존에는 영어 대소문자, 띄어쓰기를 모두 구분해서 정확하게 검색해야 데이터를 가져올 수 있었음)
- getGameDBs 의 keyword 조건 required = false 로 수정 (keyword가 없으면 단순 나열, keyword가 있으면 검색)
- h2 database 테스트용 import.sql 파일 업로드
- readRandomGameDB (랜덤 게임 추천) 숫자가 0이 나올 시, 0이 아닌 숫자가 나올 때까지 리롤하는 기능 추가

## trouble shooting & 어려웠던 점
- could not locate named parameter 에러가 발생하여 검색이 안되는 현상 (파라미터 "keyword"를 찾아야 하는데, Query 문 안에서 replace 메소드 안에 keyword를 넣으면 인식을 못하는 듯)
-> 검색 keyword는 service 단에서 replace / lowercase 처리, 데이터는 repository 단에서 @Query 문에서 replace / lower 처리해서 해결