### PR TITLE
[fe/fe-modalView] Modal View

### DIFF
--- a/client/src/components/Popup.jsx
+++ b/client/src/components/Popup.jsx
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+
+const Background = styled.div`
+  background: rgba(229, 229, 229, 0.2);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const PopupWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  /* 버튼이 1개면 4개 컬럼, 2개면 6개 컬럼 너비 */
+  width: ${({ button2 }) => (button2 ? 'var(--col-6)' : 'var(--col-4)')};
+`;
+
+const Title = styled.div`
+  margin-bottom: 56px;
+
+  .title {
+    font-size: var(--font-head2-size);
+    font-weight: var(--font-weight-medium);
+  }
+`;
+
+const Content = styled.div`
+  margin-bottom: 56px;
+
+  .content {
+    font-size: var(--font-head3-size);
+  }
+`;
+
+const ButtonWrap = styled.div`
+  display: flex;
+  width: 100%;
+
+  button {
+    flex: 1;
+
+    :first-child {
+      /* 버튼이 1개면 오른쪽 마진 16px, 없으면 0 */
+      margin-right: ${({ button2 }) => (button2 ? '16px' : '0')};
+    }
+  }
+`;
+
+const Popup = ({ title, content, button1, button2 }) => {
+  return (
+    <Background>
+      <PopupWrap className="card big" button2={button2}>
+        <Title>
+          <div className="title">{title}</div>
+        </Title>
+        <Content>
+          <p className="content">{content}</p>
+        </Content>
+        <ButtonWrap button2={button2}>
+          <button className="em">{button1}</button>
+          {button2 ? <button className="normal">{button2}</button> : null}
+        </ButtonWrap>
+      </PopupWrap>
+    </Background>
+  );
+};
+
+export default Popup;

--- a/client/src/components/Popup.jsx
+++ b/client/src/components/Popup.jsx
@@ -5,7 +5,7 @@ const Background = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -16,8 +16,8 @@ const PopupWrap = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  /* 버튼이 1개면 4개 컬럼, 2개면 6개 컬럼 너비 */
-  width: ${({ button2 }) => (button2 ? 'var(--col-6)' : 'var(--col-4)')};
+  margin-left: 200px;
+  width: var(--col-6);
 `;
 
 const Title = styled.div`
@@ -39,10 +39,11 @@ const Content = styled.div`
 
 const ButtonWrap = styled.div`
   display: flex;
+  justify-content: center;
   width: 100%;
 
   button {
-    flex: 1;
+    width: calc((100% - 24px) / 2);
 
     :first-child {
       /* 버튼이 1개면 오른쪽 마진 16px, 없으면 0 */


### PR DESCRIPTION
## 작업개요
- 공통 팝업용 모달 컴포넌트

## worklog
- 공통 팝업창에 props로 버튼을 2개 주어서 2개일 경우 큰 팝업창, 1개일 경우 작은 팝업창이 나타나도록 표시
- title, content, button을 props로 활용해 재사용 할 수 있게 작업

## trouble shooting & 어려웠던 점
- 상하 중앙 정렬.. 가장 바깥에 `height: 100%;`를 주면 헤더 아래 화면의 중앙에 정렬되기 때문에 모달 창이 너무 아래에 내려옴
![height:100%](https://user-images.githubusercontent.com/111413253/211783095-4fcc0286-53af-4654-a6d0-7444629b8fc4.png)
- `position: absolute;`, `top: 0;`, `left: 0;`를 주어 중앙 정렬 -> 더 좋은 방법이 있다면 알려주세요!
- 🥕 `position: absolute;`를 주어도 전체 화면이 아닌 Nav 컴포넌트를 제외한 자리만 인식해서 dim 배경이 화면 전체에 깔리지 않음 🥕
![recent](https://user-images.githubusercontent.com/111413253/211783906-446cd680-5a6c-4378-9423-3995954480fe.png)