### PR TITLE
[feat/fe-profileAPI] Profile page API

### DIFF
--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -113,7 +113,7 @@ const ProfileCard = ({
           {image ? (
             <img
               className="img_profile"
-              src={image.uploadFileName}
+              src={image.storeFileName}
               alt="프로필 이미지"
             />
           ) : (

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import { ReactComponent as ProfileImg } from '../assets/defaultImg.svg';
 import { ReactComponent as Setting } from '../assets/settingsIcon.svg';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
-import games from '../data/dummyGames.json';
 
 const ProfileWrap = styled.div`
   width: var(--col-4);
@@ -94,7 +93,16 @@ const GameWrap = styled.div`
   }
 `;
 
-const ProfileCard = () => {
+const ProfileCard = ({
+  image,
+  nickname,
+  identifier,
+  following,
+  follower,
+  likes,
+  games,
+  introduction,
+}) => {
   /* 더미 데이터 */
   const isMe = true;
 
@@ -102,11 +110,19 @@ const ProfileCard = () => {
     <div>
       <ProfileWrap className="card sm">
         <InformWrap>
-          <ProfileImg className="img_profile" />
+          {image ? (
+            <img
+              className="img_profile"
+              src={image.uploadFileName}
+              alt="프로필 이미지"
+            />
+          ) : (
+            <ProfileImg className="img_profile" />
+          )}
           <div className="name_content">
             {/* 정보 수정 필요 */}
-            <div className="nickname">닉네임</div>
-            <div className="identifier">아이디</div>
+            <div className="nickname">{nickname}</div>
+            <div className="identifier">{identifier}</div>
           </div>
           {/* 자기 자신 여부에 따라 표시 아이콘 달라짐 */}
           {isMe ? (
@@ -125,15 +141,15 @@ const ProfileCard = () => {
           {/* 정보 수정 필요 */}
           <Follow>
             <div className="follow">팔로잉</div>
-            <div className="number">123</div>
+            <div className="number">{following}</div>
           </Follow>
           <Follow>
             <div className="follow">팔로워</div>
-            <div className="number">1234</div>
+            <div className="number">{follower}</div>
           </Follow>
           <Follow>
             <div className="follow">좋아요</div>
-            <div className="number">1234</div>
+            <div className="number">{likes}</div>
           </Follow>
         </FollowWrap>
         {isMe ? null : (
@@ -147,9 +163,9 @@ const ProfileCard = () => {
         <div className="inform_title">주로하는 게임</div>
         <GameWrap>
           <ul>
-            {games.games.map((game) => (
-              <li key={game.id} className="normal game_title">
-                {game.title}
+            {games.map((game, idx) => (
+              <li key={idx} className="normal game_title">
+                {game}
               </li>
             ))}
           </ul>
@@ -158,7 +174,7 @@ const ProfileCard = () => {
       <ProfileWrap className="card sm">
         {/* 정보 수정 필요 */}
         <div className="inform_title">자기 소개</div>
-        <div className="inform_content">에우프로시네 갈사람</div>
+        <div className="inform_content">{introduction}</div>
       </ProfileWrap>
     </div>
   );

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -120,7 +120,6 @@ const ProfileCard = ({
             <ProfileImg className="img_profile" />
           )}
           <div className="name_content">
-            {/* 정보 수정 필요 */}
             <div className="nickname">{nickname}</div>
             <div className="identifier">{identifier}</div>
           </div>
@@ -138,7 +137,6 @@ const ProfileCard = ({
           )}
         </InformWrap>
         <FollowWrap>
-          {/* 정보 수정 필요 */}
           <Follow>
             <div className="follow">팔로잉</div>
             <div className="number">{following}</div>
@@ -172,7 +170,6 @@ const ProfileCard = ({
         </GameWrap>
       </ProfileWrap>
       <ProfileWrap className="card sm">
-        {/* 정보 수정 필요 */}
         <div className="inform_title">자기 소개</div>
         <div className="inform_content">{introduction}</div>
       </ProfileWrap>

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -161,9 +161,9 @@ const ProfileCard = ({
         <div className="inform_title">주로하는 게임</div>
         <GameWrap>
           <ul>
-            {games.map((game, idx) => (
-              <li key={idx} className="normal game_title">
-                {game}
+            {games.map((game) => (
+              <li key={game.id} className="normal game_title">
+                {game.korTitle}
               </li>
             ))}
           </ul>

--- a/client/src/components/ProfileContent.jsx
+++ b/client/src/components/ProfileContent.jsx
@@ -20,14 +20,19 @@ const TabWrap = styled.div`
   }
 `;
 
-const ProfileContent = ({ isMatch, isStory }) => {
+const ProfileContent = ({ isMatch, isStory, mathchBoards, userBoards }) => {
   return (
     <ContentWrap className="card">
       <TabWrap>
         <div className={'tab' + (isMatch ? ' active' : '')}>매칭글</div>
         <div className={'tab' + (isStory ? ' active' : '')}>스토리</div>
       </TabWrap>
-      <ProfileContentList isMatch={isMatch} isStory={isStory} />
+      <ProfileContentList
+        isMatch={isMatch}
+        isStory={isStory}
+        mathchBoards={mathchBoards}
+        userBoards={userBoards}
+      />
       <Pagination />
     </ContentWrap>
   );

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
 import { ReactComponent as Comment } from '../assets/sms.svg';
-import dummyMatchContents from '../data/dummyMatchContents.json';
-import dummyStoryContents from '../data/dummyStoryContents.json';
 
 const ListWrap = styled.div`
   li {
@@ -74,58 +72,51 @@ const ListWrap = styled.div`
   }
 `;
 
-const ProfileContentList = ({ isMatch, isStory }) => {
+const ProfileContentList = ({ isMatch, isStory, matchBoards, userBoards }) => {
   return (
     <ListWrap>
       <ul>
         {isMatch
-          ? dummyMatchContents.contents.map((content) => (
-              <li key={content.id}>
+          ? matchBoards.map((match) => (
+              <li key={match.id}>
                 <div className="game_container">
-                  <img
-                    className="game_icon"
-                    src={content.icon}
-                    alt="게임 아이콘"
-                  />
+                  <img className="game_icon" src={''} alt="게임 아이콘" />
                 </div>
                 <div className="content_container match">
-                  <div className="content_title">{content.title}</div>
+                  <div className="content_title">{match.title}</div>
                   <div className="content_date">
-                    {new Date(content.createdAt).toLocaleString()}
+                    {new Date(match.createdAt).toLocaleString()}
                   </div>
                 </div>
               </li>
             ))
           : null}
         {isStory
-          ? dummyStoryContents.contents.map((content) => (
-              <li key={content.id}>
+          ? userBoards.map((story) => (
+              <li key={story.id}>
                 <div className="content_container story">
-                  <div className="content_title">{content.title}</div>
+                  <div className="content_title">{story.content}</div>
                   <div className="content_date">
-                    {new Date(content.createdAt).toLocaleString()}
+                    {new Date(story.createdAt).toLocaleString()}
                   </div>
                   <div className="content_count">
-                    {content.likeCount ? (
+                    {story.likeCount ? (
                       <div className="content_like">
                         <Heart width="10px" />
-                        <span>{content.likeCount}</span>
+                        <span>{story.likeCount}</span>
                       </div>
                     ) : null}
-                    {content.commentCount ? (
+                    {story.commentCount ? (
                       <div className="content_comment">
                         <Comment width="10px" />
-                        <span>{content.commentCount}</span>
+                        <span>{story.commentCount}</span>
                       </div>
                     ) : null}
                   </div>
                 </div>
-                {content.content.contentImage ? (
+                {story.image ? (
                   <div className="image_container">
-                    <img
-                      src={content.content.contentImage}
-                      alt="스토리 이미지"
-                    />
+                    <img src={story.image.storeFileName} alt="스토리 이미지" />
                   </div>
                 ) : null}
               </li>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,3 +1,6 @@
+import axios from 'axios';
+import { useState } from 'react';
+import { useEffect } from 'react';
 import styled from 'styled-components';
 import ProfileCard from '../components/ProfileCard';
 import ProfileContent from '../components/ProfileContent';
@@ -7,12 +10,37 @@ const ProfileWrap = styled.div`
 `;
 
 const Profile = () => {
+  const URL = `https://f841-14-63-98-43.jp.ngrok.io`;
+  const [user, setUser] = useState({});
   const isMatch = false;
   const isStory = true;
 
+  useEffect(() => {
+    async function getMember() {
+      await axios
+        .get(`${URL}/api/members/98`, {
+          // ngrok get cors 해결용
+          headers: { 'ngrok-skip-browser-warning': '69420' },
+        })
+        .then((res) => setUser(res.data.data));
+    }
+    getMember();
+  }, []);
+
+  console.log(user);
+
   return (
     <ProfileWrap>
-      <ProfileCard />
+      <ProfileCard
+        iamge={user.iamge}
+        nickname={user.nickname}
+        identifier={'user.identifier'}
+        following={user.following}
+        follower={user.follower}
+        likes={user.likes}
+        games={user.games}
+        introduction={user.introduction}
+      />
       <ProfileContent isMatch={isMatch} isStory={isStory} />
     </ProfileWrap>
   );

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -11,39 +11,43 @@ const ProfileWrap = styled.div`
 
 const Profile = () => {
   const URL = `https://f841-14-63-98-43.jp.ngrok.io`;
-  const [user, setUser] = useState({});
+  const [user, setUser] = useState(null);
   const isMatch = false;
   const isStory = true;
 
   useEffect(() => {
-    async function getMember() {
-      await axios
-        .get(`${URL}/api/members/98`, {
-          // ngrok get cors 해결용
-          headers: { 'ngrok-skip-browser-warning': '69420' },
-        })
-        .then((res) => setUser(res.data.data));
-    }
-    getMember();
+    axios
+      .get(`${URL}/api/members/98`, {
+        // ngrok get cors 해결용
+        headers: { 'ngrok-skip-browser-warning': '69420' },
+      })
+      .then((res) => setUser(res.data.data));
   }, []);
 
-  console.log(user);
-
-  return (
-    <ProfileWrap>
-      <ProfileCard
-        iamge={user.iamge}
-        nickname={user.nickname}
-        identifier={'user.identifier'}
-        following={user.following}
-        follower={user.follower}
-        likes={user.likes}
-        games={user.games}
-        introduction={user.introduction}
-      />
-      <ProfileContent isMatch={isMatch} isStory={isStory} />
-    </ProfileWrap>
-  );
+  if (user) {
+    return (
+      <ProfileWrap>
+        <ProfileCard
+          iamge={user.iamge}
+          nickname={user.nickname}
+          identifier={'user.identifier'}
+          following={user.following}
+          follower={user.follower}
+          likes={user.likes}
+          games={user.games}
+          introduction={user.introduction}
+        />
+        <ProfileContent
+          isMatch={isMatch}
+          isStory={isStory}
+          matchBoards={user.matchBoards}
+          userBoards={user.userBoards}
+        />
+      </ProfileWrap>
+    );
+  } else {
+    return null;
+  }
 };
 
 export default Profile;

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { API_URL } from '../data/apiUrl';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import styled from 'styled-components';
@@ -10,14 +11,13 @@ const ProfileWrap = styled.div`
 `;
 
 const Profile = () => {
-  const URL = `https://f841-14-63-98-43.jp.ngrok.io`;
   const [user, setUser] = useState(null);
   const isMatch = false;
   const isStory = true;
 
   useEffect(() => {
     axios
-      .get(`${URL}/api/members/98`, {
+      .get(`${API_URL}/api/members/98`, {
         // ngrok get cors 해결용
         headers: { 'ngrok-skip-browser-warning': '69420' },
       })


### PR DESCRIPTION
## 작업개요
`Profile` 페이지 API 연결

## worklog
- `Profile` 페이지에 API를 연결했습니다. 제 브랜치에서는 로그인 작업이 끝나지 않은 상태이기 때문에 임의로 98번 id의 정보를 불러왔습니다!
- 해당 페이지에 들어가는 컴포넌트가 크게는 왼쪽의 `ProfileCard` 컴포넌트, 오른쪽의 `ProfileContent` 컴포넌트로 2개라서 전체 API 호출은 `Profile` 페이지에서, 개별 데이터 처리는 각 컴포넌트에서 필요로 하는 데이터를 `props`로 내려주었습니다.
- `ProfileCard` 컴포넌트는 `image`, `nickname`, `identifier`, `following`, `follower`, `likes`, `games`, `introduction` / `ProfileContent` 컴포넌트는 `matchBoards`, `userBoards` 데이터를 각각 필요로 합니다.
> ### Profile page
![프로필페이지](https://user-images.githubusercontent.com/111413253/212700050-67774245-66e4-4308-b4c1-9205ddf1f6f8.png)

## trouble shooting & 어려웠던 점
- 데이터 `get` 요청시 `identifier` 값이 없어서 현재 `user.identifier`로 렌더링됩니다. ⇒ 백엔드 처리해주기로 함!
- 페이지네이션 API 요청이 감이 잡히지 않아 고민됩니다...🤔 일단 지금은 머리가 굴러가지 않는 상태에요 🥹
- `useEffect`를 사용해 API를 호출했는데 렌더링 과정에서 `undefined`를 먼저 호출한 뒤에 데이터가 `useState`에 저장이 되어서 배열에 대한 `map` 함수를 사용한 부분이 자꾸 오류를 일으켰습니다🤬 (`map`을 사용할 수 없는 타입이라는 오류) ⇒ 렌더링을 조건부로 넣어서 해결했습니다!
> ### 참고용 코드
```javascript
const Profile = () => {
  const [user, setUser] = useState(null);

  useEffect(() => {
    axios
      .get(`${URL}`, {
        // ngrok get cors 해결용
        headers: { 'ngrok-skip-browser-warning': '69420' },
      })
      .then((res) => setUser(res.data.data));
  }, []);

  if (user) {
    return (
      <렌더링 할 내용/>
    );
  } else {
    return null;
  }
};

export default Profile;
```
> 근데 이 부분은 로딩 페이지 넣어서 해결할 수도 있겠다는 생각이 들어요! 로딩 페이지.. 만드실건가요?!