### PR TITLE
[feat/fe-matchpagenation]매칭하기 페이지네이션

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -40,37 +40,35 @@ const MainWrap = styled.section`
 `;
 
 const App = () => {
-
-	return (
-		<Wrap>
-			<Router basename={process.env.PUBLIC_URL}>
-				<Nav />
-				<MainWrap>
-					<Header />
-					{/* 아래 main 안에 각 페이지가 들어갑니다. */}
-					<main className="container">
-						<Routes>
-							<Route path="/" element={<Matching />} />
-							<Route path="/:boardid" element={<MatchingDetail />} />
-							<Route path="/matchwrite" element={<MatchingWrite />} />
-							<Route path="/:boardid/edit" element={<MatchingEdit />} />
-							<Route path="/story" element={<Story />} />
-							<Route path="/:userid/:boardid" element={<StoryDetail />} />
-							<Route path="/:userid/:boardid/edit" element={<StoryEdit />} />
-							<Route path="/storywrite" element={<StoryWrite />} />
-							<Route path="/:userid" element={<Profile />} />
-							<Route path="/:userid/edit" element={<ProfileEdit />} />
-							<Route path="/login" element={<Login />} />
-							<Route path="/signup" element={<Signup />} />
-							<Route path="/quit" element={<Quit />} />
-							<Route path="/game" element={<GameRecommend />} />
-						</Routes>
-					</main>
-				</MainWrap>
-			</Router>
-		</Wrap>
-	);
-
+  return (
+    <Wrap>
+      <Router basename={process.env.PUBLIC_URL}>
+        <Nav />
+        <MainWrap>
+          <Header />
+          {/* 아래 main 안에 각 페이지가 들어갑니다. */}
+          <main className="container">
+            <Routes>
+              <Route path="/" element={<Matching />} />
+              <Route path="/:boardid/detail" element={<MatchingDetail />} />
+              <Route path="/matchwrite" element={<MatchingWrite />} />
+              <Route path="/:boardid/edit" element={<MatchingEdit />} />
+              <Route path="/story" element={<Story />} />
+              <Route path="/:userid/:boardid" element={<StoryDetail />} />
+              <Route path="/:userid/:boardid/edit" element={<StoryEdit />} />
+              <Route path="/storywrite" element={<StoryWrite />} />
+              <Route path="/:userid" element={<Profile />} />
+              <Route path="/:userid/edit" element={<ProfileEdit />} />
+              <Route path="/login" element={<Login />} />
+              <Route path="/signup" element={<Signup />} />
+              <Route path="/quit" element={<Quit />} />
+              <Route path="/game" element={<GameRecommend />} />
+            </Routes>
+          </main>
+        </MainWrap>
+      </Router>
+    </Wrap>
+  );
 };
 
 export default App;

--- a/client/src/components/DropDown.jsx
+++ b/client/src/components/DropDown.jsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { ReactComponent as Arrow } from "./../assets/arrowDown.svg";
-
 const DropdownContainer = styled.div`
   position: relative;
 `;

--- a/client/src/components/MatchDetails.jsx
+++ b/client/src/components/MatchDetails.jsx
@@ -5,7 +5,6 @@ import { API_URL } from "../data/apiUrl";
 import axios from "axios";
 import { Link, useNavigate } from "react-router-dom";
 import matchGame from "../util/matchGame";
-import { ReactComponent as DefaultProfileImg } from "./../assets/defaultImg.svg";
 const Detail = styled.div`
   width: var(--col-9);
   margin-right: 32px;
@@ -112,11 +111,7 @@ const MatchDetails = ({ data, boardId }) => {
           <div className="title">{data.title}</div>
           <div className="game">{data.game.korTitle}</div>
         </Info>
-        {data.image ? (
-          <img src={matchGame(data).image} alt="게임아이콘" />
-        ) : (
-          <DefaultProfileImg />
-        )}
+        <img src={matchGame(data.game).image} alt="게임아이콘" />
       </Div>
       <Div>
         <span>팀원수</span>

--- a/client/src/components/MatchPagination.jsx
+++ b/client/src/components/MatchPagination.jsx
@@ -1,0 +1,64 @@
+import styled from "styled-components";
+import { ReactComponent as ArrowBack } from "../assets/arrowBack.svg";
+import { ReactComponent as ArrowForward } from "../assets/arrowForward.svg";
+import { useState } from "react";
+const Wrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Btn = styled.button`
+  &:hover,
+  :active {
+    color: var(--primary-color);
+  }
+`;
+const MatchPagination = ({ setPage, page, total }) => {
+  const [currPage, setCurrPage] = useState(page);
+  let firstNum = currPage - (currPage % 5) + 1;
+  let lastNum = currPage - (currPage % 5) + 5;
+  let pageCount = 5;
+  if (lastNum > total) {
+    pageCount = total % 5;
+  }
+  return (
+    <Wrap>
+      <Btn
+        onClick={() => {
+          if (currPage < 1) {
+            return;
+          }
+          setPage(page - 1);
+          setCurrPage(page - 2);
+        }}
+      >
+        <ArrowBack />
+      </Btn>
+      {Array(pageCount)
+        .fill()
+        .map((_, i) => (
+          <Btn
+            key={i + 1}
+            onClick={() => {
+              setPage(firstNum + i);
+            }}
+          >
+            {firstNum + i}
+          </Btn>
+        ))}
+      <Btn
+        onClick={() => {
+          if (total <= page) {
+            return;
+          }
+          setPage(page + 1);
+          setCurrPage(page);
+        }}
+      >
+        <ArrowForward />
+      </Btn>
+    </Wrap>
+  );
+};
+export default MatchPagination;

--- a/client/src/components/MatchingCard.jsx
+++ b/client/src/components/MatchingCard.jsx
@@ -73,7 +73,9 @@ const MatchingCard = ({ data }) => {
     <Card className="card">
       <Space>
         <ImgWrap>
-          <img src={matchGame(data.game).image} />
+          {data.game && (
+            <img src={matchGame(data.game).image} alt="게임아이콘" />
+          )}
         </ImgWrap>
 
         <Title>

--- a/client/src/pages/Matching.jsx
+++ b/client/src/pages/Matching.jsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import MatchingCard from "../components/MatchingCard";
 import SearchBar from "../components/SearchBar";
 import WriteFloatButton from "../components/WriteFloatButton";
+import MatchPagination from "../components/MatchPagination";
 import { Link, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import { API_URL } from "../data/apiUrl";
@@ -21,7 +22,8 @@ const Ul = styled.ul`
 const Matching = () => {
   const [isLogin, setIsLogin] = useState(false);
   const [matchinglist, setMatchinglist] = useState([]);
-
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(1);
   const navigate = useNavigate();
   const matchingBtn = () => {
     if (isLogin) {
@@ -37,11 +39,14 @@ const Matching = () => {
   }, [isLogin]);
   useEffect(() => {
     axios
-      .get(`${API_URL}/api/matches`, {
+      .get(`${API_URL}/api/matches?page=${page}`, {
         headers: { "ngrok-skip-browser-warning": "69420" },
       })
-      .then((res) => setMatchinglist(res.data.data));
-  }, []);
+      .then((res) => {
+        setMatchinglist(res.data.data);
+        setTotal(res.data.pageInfo.totalPages);
+      });
+  }, [page]);
   return (
     <Wrap>
       <SearchBar />
@@ -55,6 +60,7 @@ const Matching = () => {
         ))}
       </Ul>
       <WriteFloatButton click={matchingBtn} />
+      <MatchPagination setPage={setPage} page={page} total={total} />
     </Wrap>
   );
 };


### PR DESCRIPTION
## 작업개요
-매칭하기 페이지네이션

## worklog
-서버에 엔드포인트에 쿼리를 사용해 페이지 별로 요청을 받아 랜더링
## trouble shooting & 어려웠던 점
- 페이지 네이션에대한 완벽한 이해는 없었고 자료를 이것저것찾아봄
<img width="748" alt="스크린샷 2023-01-18 오후 8 56 47" src="https://user-images.githubusercontent.com/110882351/213165529-c163db48-4ca9-49fb-a314-300ca62aeefc.png">
페이지 네이션 공식이 있었고
 const [currPage, setCurrPage] = useState(타겟이되는 페이지);
  let firstNum = currPage - (currPage % 5) + 1; 
  let lastNum = currPage - (currPage % 5) + 5;
page : 1, firstNum : 1, lastNum : 5 currPage : 1
page : 2, firstNum : 1, lastNum : 5 currPage : 1
page : 3, firstNum : 1, lastNum : 5 currPage : 1
page : 4, firstNum : 1, lastNum : 5 currPage : 1
**page : 5, firstNum : 1, lastNum : 5 currPage : 1**
page : 6, firstNum : 6, lastNum : 10 currPage : 6
page : 7, firstNum : 6, lastNum : 10 currPage : 6
page : 8, firstNum : 6, lastNum : 10 currPage : 6
page : 9, firstNum : 6, lastNum : 10 currPage : 6
**page : 10, firstNum : 11, lastNum : 15 currPage : 6**
**ArrowForward,ArrowBack**값에 -1 +1만하면될줄알았는데  이부분이 아직 잘이해가되지않아서 고찰을 해봐야 할거 같다