### PR TITLE
feat/be-matchblock

### DIFF
--- a/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/controller/MatchBoardController.java
@@ -59,8 +59,9 @@ public class MatchBoardController {
 
     @GetMapping("/{match-id}")
     public ResponseEntity getMatchBoard(@PathVariable("match-id")
-                                        @Positive(message = "id 값은 0보다 커야합니다.") Long id) {
-        MatchBoard matchBoard = matchBoardService.readMatchBoard(id);
+                                        @Positive(message = "id 값은 0보다 커야합니다.") Long id,
+                                        @AuthenticationPrincipal Member user) {
+        MatchBoard matchBoard = matchBoardService.readMatchBoard(id, user);
 
         return new ResponseEntity(
                 new SingleResponseDto<>(mapper.matchBoardToMatchBoardResponse(matchBoard)), HttpStatus.OK);
@@ -68,9 +69,9 @@ public class MatchBoardController {
 
     @GetMapping
     public ResponseEntity getMatchBoards(@RequestParam(value = "keyword", required = false) String keyword,
-                                         @PageableDefault(size = 8, sort = "id", direction = Sort.Direction.DESC)
-                                         Pageable pageable) {
-        Page<MatchBoard> matchBoardPage = matchBoardService.readMatchBoards(keyword, pageable.previousOrFirst());
+                                         @PageableDefault(size = 8) Pageable pageable,
+                                         @AuthenticationPrincipal Member user) {
+        Page<MatchBoard> matchBoardPage = matchBoardService.readMatchBoards(keyword, pageable.previousOrFirst(), user);
         List<MatchBoard> matchBoards = matchBoardPage.getContent();
 
         return new ResponseEntity(
@@ -82,8 +83,8 @@ public class MatchBoardController {
     @DeleteMapping("/{match-id}")
     public ResponseEntity deleteMatchBoard(@PathVariable("match-id")
                                            @Positive(message = "id 값은 0보다 커야합니다.") Long id,
-                                           @AuthenticationPrincipal Member member) {
-        matchBoardService.deleteMatchBoard(member, id);
+                                           @AuthenticationPrincipal Member user) {
+        matchBoardService.deleteMatchBoard(user, id);
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }

--- a/server/src/main/java/mainproject33/domain/matchboard/repository/MatchBoardRepository.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/repository/MatchBoardRepository.java
@@ -7,9 +7,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface MatchBoardRepository extends JpaRepository<MatchBoard, Long> {
-    @Query(value = "select * from MATCH_BOARD where title like %:keyword% or content like %:keyword%", nativeQuery = true)
-    Page<MatchBoard> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+    @Query(value = "select * from MATCH_BOARD where title like %:keyword% or content like %:keyword% order by id desc", nativeQuery = true)
+    List<MatchBoard> findByKeyword(@Param("keyword") String keyword);
+
+    @Override
+    @Query(value = "select * from MATCH_BOARD order by id desc", nativeQuery = true)
+    List<MatchBoard> findAll();
 
     @Query(value = "select * from MATCH_BOARD where member_id = :memberId", nativeQuery = true)
     Page<MatchBoard> findByMemberId(@Param("memberId")Long memberId, Pageable pageable);

--- a/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
+++ b/server/src/main/java/mainproject33/domain/matchboard/service/MatchBoardService.java
@@ -3,21 +3,26 @@ package mainproject33.domain.matchboard.service;
 import lombok.RequiredArgsConstructor;
 import mainproject33.domain.matchboard.entity.MatchBoard;
 import mainproject33.domain.matchboard.repository.MatchBoardRepository;
+import mainproject33.domain.member.entity.Block;
 import mainproject33.domain.member.entity.Member;
+import mainproject33.domain.member.repository.BlockRepository;
 import mainproject33.global.exception.BusinessLogicException;
 import mainproject33.global.exception.ExceptionMessage;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MatchBoardService {
 
     private final MatchBoardRepository matchBoardRepository;
+    private final BlockRepository blockRepository;
 
     public MatchBoard createMatchBoard(MatchBoard matchBoard) {
         return matchBoardRepository.save(matchBoard);
@@ -43,20 +48,34 @@ public class MatchBoardService {
         }
     }
 
-    public MatchBoard readMatchBoard(long id) {
-        MatchBoard findMatchBoard = matchBoardRepository.findById(id)
-                .orElseThrow(()
-                        -> new NoSuchElementException(ExceptionMessage.MATCH_BOARD_NOT_FOUND.get()));
+    public MatchBoard readMatchBoard(long id, Member user) {
+        MatchBoard matchBoard = findVerifiedMatchBoard(id);
 
-        return findMatchBoard;
+        if (user == null) { // 비회원
+            return matchBoard;
+        } else { // 회원
+            List<Long> blockedIdList = getBlockedList(user.getId());
+
+            boolean checkBlock = blockedIdList.contains(matchBoard.getMember().getId()); // 유저가 해당 게시물을 작성한 회원의 block 여부
+
+            if (!checkBlock) return matchBoard;
+            else throw new BusinessLogicException(ExceptionMessage.MATCH_BOARD_BLOCKED);
+        }
     }
 
-    public Page<MatchBoard> readMatchBoards(String keyword, Pageable pageable) {
-        if (keyword == null) {
-            return matchBoardRepository.findAll(pageable);
-        } else {
-            return matchBoardRepository.findByKeyword(keyword, pageable);
+    public Page<MatchBoard> readMatchBoards(String keyword, Pageable pageable, Member user) {
+        List<MatchBoard> list;
+
+        if (user == null) { // 비회원
+            if (keyword == null) list = matchBoardRepository.findAll();
+            else list = matchBoardRepository.findByKeyword(keyword);
+        } else { // 회원
+            List<Long> blockedIdList = getBlockedList(user.getId());
+
+            if (keyword == null) list = filterMatchBoards(blockedIdList, matchBoardRepository.findAll());
+            else list = filterMatchBoards(blockedIdList, matchBoardRepository.findByKeyword(keyword));
         }
+        return toPageImpl(pageable, list);
     }
 
     public Page<MatchBoard> readProfileMatchBoards(Long memberId, Pageable pageable) {
@@ -80,5 +99,27 @@ public class MatchBoardService {
     private MatchBoard findVerifiedMatchBoard(long id) {
         return matchBoardRepository.findById(id).orElseThrow(() ->
                 new BusinessLogicException(ExceptionMessage.MATCH_BOARD_NOT_FOUND));
+    }
+
+    private List<Long> getBlockedList(long blockerId) {
+        List<Block> blockedList = blockRepository.findByBlockerId(blockerId);
+        List<Long> blockedIdList = blockedList.stream()
+                .mapToLong(block -> block.getBlocked().getId())
+                .boxed().collect(Collectors.toList());
+
+        return blockedIdList;
+    }
+
+    private List<MatchBoard> filterMatchBoards(List<Long> blockedIdList, List<MatchBoard> list) {
+        return list.stream()
+                .filter(matchBoard -> !blockedIdList.contains(matchBoard.getMember().getId()))
+                .collect(Collectors.toList());
+    }
+
+    private PageImpl toPageImpl(Pageable pageable, List<MatchBoard> list) {
+        final int start = (int) pageable.getOffset();
+        final int end = Math.min((start + pageable.getPageSize()), list.size());
+
+        return new PageImpl<>(list.subList(start, end), pageable, list.size());
     }
 }

--- a/server/src/main/java/mainproject33/domain/member/repository/BlockRepository.java
+++ b/server/src/main/java/mainproject33/domain/member/repository/BlockRepository.java
@@ -4,11 +4,13 @@ import mainproject33.domain.member.entity.Block;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BlockRepository extends JpaRepository<Block, Long> {
 
     @Query(value = "SELECT * FROM BLOCK WHERE BLOCKER_ID = :blockerId AND BLOCKED_ID = :blockedId", nativeQuery = true)
     Optional<Block> findByBlock(Long blockerId, Long blockedId);
-
+    @Query(value = "SELECT * FROM BLOCK WHERE BLOCKER_ID = :blockerId", nativeQuery = true)
+    List<Block> findByBlockerId(Long blockerId);
 }

--- a/server/src/main/java/mainproject33/global/exception/ExceptionMessage.java
+++ b/server/src/main/java/mainproject33/global/exception/ExceptionMessage.java
@@ -4,8 +4,9 @@ import lombok.Getter;
 
 public enum ExceptionMessage {
     //=========matchBoard=========//
-    MATCH_BOARD_NOT_FOUND("존재하지 않는 매칭 게시글 입니다."),
-    MATCH_BOARD_ID_NOT_FOUND("존재하지 않는 매칭 게시글 식별자 입니다."),
+    MATCH_BOARD_NOT_FOUND("존재하지 않는 매칭 게시글입니다."),
+    MATCH_BOARD_ID_NOT_FOUND("존재하지 않는 매칭 게시글 식별자입니다."),
+    MATCH_BOARD_BLOCKED("차단된 회원의 매칭 게시글입니다."),
 
     //=========member=========//
 


### PR DESCRIPTION
## 작업개요
- 매칭 게시글 Block 기능 구현

## worklog
- 현재 유저의 로그인 정보를 기반으로 해서 blockedIdList 가져오는 로직 구현
- blockedIdList 기반 filtering 로직 구현
- 단일 GET 시 차단 회원이 올린 글이라면 ExceptionMessage return
- 현재 유저가 비회원인 경우 모든 게시물을 볼 수 있도록 구현

## trouble shooting & 어려웠던 점
- PageableDefault 로 설정한 Direction 값이 먹지 않아, repository @Query 문으로 해결 (findAll() override, findByKeyword 쿼리문 수정)
-> 원래 pageable 값을 repository 에서 parameter 로 받았으나, 받지 않는 것으로 수정 이후 목록이 ASC 순으로 나온 것으로 보아, pageable 의 설정값은 repository 에서 찾을 때만 적용되는 값인 것으로 추정..