### PR TITLE
[feat/fe-profilesAPI] API related to Profile

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -57,8 +57,8 @@ const App = () => {
 							<Route path="/:userid/:boardid" element={<StoryDetail />} />
 							<Route path="/:userid/:boardid/edit" element={<StoryEdit />} />
 							<Route path="/storywrite" element={<StoryWrite />} />
-							<Route path="/:userid" element={<Profile />} />
-							<Route path="/:userid/edit" element={<ProfileEdit />} />
+							<Route path="/profile/:userid" element={<Profile />} />
+							<Route path="/profile/:userid/edit" element={<ProfileEdit />} />
 							<Route path="/login" element={<Login />} />
 							<Route path="/signup" element={<Signup />} />
 							<Route path="/quit" element={<Quit />} />

--- a/client/src/components/Nav.jsx
+++ b/client/src/components/Nav.jsx
@@ -1,132 +1,147 @@
-import styled from "styled-components";
-import { ReactComponent as LogoImg } from "./../assets/Logo.svg";
-import { ReactComponent as MenuIconMatch } from "./../assets/handshakeIcon.svg";
-import { ReactComponent as MenuIconStory } from "./../assets/boardIcon.svg";
-import { ReactComponent as MenuIconGame } from "./../assets/gameIcon.svg";
-import { ReactComponent as MenuIconProfile } from "./../assets/personIcon.svg";
-import { NavLink } from "react-router-dom";
+import styled from 'styled-components';
+import { ReactComponent as LogoImg } from './../assets/Logo.svg';
+import { ReactComponent as MenuIconMatch } from './../assets/handshakeIcon.svg';
+import { ReactComponent as MenuIconStory } from './../assets/boardIcon.svg';
+import { ReactComponent as MenuIconGame } from './../assets/gameIcon.svg';
+import { ReactComponent as MenuIconProfile } from './../assets/personIcon.svg';
+import { NavLink } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 const NavWrap = styled.nav`
-	position: relative;
-	flex: none;
-	width: 200px;
-	background: var(--bg-card-color);
+  position: relative;
+  flex: none;
+  width: 200px;
+  background: var(--bg-card-color);
 
-	.copy {
-		position: absolute;
-		left: 0;
-		bottom: 0;
-		width: 100%;
-		padding: 48px 16px;
-		text-align: center;
-		font-size: var(--font-caption-size);
-	}
+  .copy {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    padding: 48px 16px;
+    text-align: center;
+    font-size: var(--font-caption-size);
+  }
 `;
 
 const LogoWrap = styled.div`
-	position: sticky;
-	width: 100%;
-	height: 112px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	a {
-		display: block;
-		width: 130px;
-		height: 35px;
-		svg {
-			width: 100%;
-			height: 100%;
-		}
-	}
+  position: sticky;
+  width: 100%;
+  height: 112px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  a {
+    display: block;
+    width: 130px;
+    height: 35px;
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
 `;
 
 const Menu = styled.ul`
-	position: sticky;
-	width: 100%;
-	padding: 0 16px;
-	li {
-		width: 100%;
-		border-radius: var(--border-raidus-md);
-		color: var(--font-color);
-		overflow: hidden;
-		a {
-			display: flex;
-			align-items: center;
-			padding: 16px;
-			color: inherit;
-			svg {
-				width: 24px;
-				height: 24px;
-				margin-right: 12px;
-				fill: var(--font-color);
-				path {
-					fill: inherit;
-				}
-			}
-			span {
-				font-size: var(--font-body2-size);
-			}
-		}
-		a:hover {
-			color: var(--grey);
-			path {
-				fill: var(--grey);
-			}
-		}
-		a.active {
-			background: var(--black);
-			color: var(--primary-color);
-			svg {
-				fill: var(--primary-color);
-			}
-		}
-		a:hover.active {
-			color: var(--primary-color);
-			path {
-				fill: var(--primary-color);
-			}
-		}
-	}
+  position: sticky;
+  width: 100%;
+  padding: 0 16px;
+  li {
+    width: 100%;
+    border-radius: var(--border-raidus-md);
+    color: var(--font-color);
+    overflow: hidden;
+    a {
+      display: flex;
+      align-items: center;
+      padding: 16px;
+      color: inherit;
+      svg {
+        width: 24px;
+        height: 24px;
+        margin-right: 12px;
+        fill: var(--font-color);
+        path {
+          fill: inherit;
+        }
+      }
+      span {
+        font-size: var(--font-body2-size);
+      }
+    }
+    a:hover {
+      color: var(--grey);
+      path {
+        fill: var(--grey);
+      }
+    }
+    a.active {
+      background: var(--black);
+      color: var(--primary-color);
+      svg {
+        fill: var(--primary-color);
+      }
+    }
+    a:hover.active {
+      color: var(--primary-color);
+      path {
+        fill: var(--primary-color);
+      }
+    }
+  }
 `;
 
 const Nav = () => {
-	return (
-		<NavWrap>
-			<LogoWrap>
-				<NavLink to="/" title="GAMETO">
-					<LogoImg />
-				</NavLink>
-			</LogoWrap>
-			<Menu>
-				<li>
-					<NavLink to="/" className={({ isActive }) => (isActive ? "active" : "")}>
-						<MenuIconMatch />
-						<span>매칭하기</span>
-					</NavLink>
-				</li>
-				<li>
-					<NavLink to="/story" className={({ isActive }) => (isActive ? "active" : "")}>
-						<MenuIconStory />
-						<span>스토리</span>
-					</NavLink>
-				</li>
-				<li>
-					<NavLink to="/game" className={({ isActive }) => (isActive ? "active" : "")}>
-						<MenuIconGame />
-						<span>오늘뭐하지?</span>
-					</NavLink>
-				</li>
-				<li>
-					<NavLink to="/:userid" className={({ isActive }) => (isActive ? "active" : "")}>
-						<MenuIconProfile />
-						<span>마이프로필</span>
-					</NavLink>
-				</li>
-			</Menu>
-			<p className="copy">© 맑게고인물 team33 2023</p>
-		</NavWrap>
-	);
+  const userid = useSelector((state) => state.islogin.memberId);
+
+  return (
+    <NavWrap>
+      <LogoWrap>
+        <NavLink to="/" title="GAMETO">
+          <LogoImg />
+        </NavLink>
+      </LogoWrap>
+      <Menu>
+        <li>
+          <NavLink
+            to="/"
+            className={({ isActive }) => (isActive ? 'active' : '')}
+          >
+            <MenuIconMatch />
+            <span>매칭하기</span>
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="/story"
+            className={({ isActive }) => (isActive ? 'active' : '')}
+          >
+            <MenuIconStory />
+            <span>스토리</span>
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="/game"
+            className={({ isActive }) => (isActive ? 'active' : '')}
+          >
+            <MenuIconGame />
+            <span>오늘뭐하지?</span>
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to={`/profile/${userid}`}
+            className={({ isActive }) => (isActive ? 'active' : '')}
+          >
+            <MenuIconProfile />
+            <span>마이프로필</span>
+          </NavLink>
+        </li>
+      </Menu>
+      <p className="copy">© 맑게고인물 team33 2023</p>
+    </NavWrap>
+  );
 };
 
 export default Nav;

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -1,8 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import styled from 'styled-components';
 import { ReactComponent as ProfileImg } from '../assets/defaultImg.svg';
 import { ReactComponent as Setting } from '../assets/settingsIcon.svg';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
+import { useState } from 'react';
+import { useEffect } from 'react';
 
 const ProfileWrap = styled.div`
   width: var(--col-4);
@@ -104,8 +107,13 @@ const ProfileCard = ({
   introduction,
 }) => {
   /* 더미 데이터 */
-  const isMe = true;
+  const [isMe, setIsMe] = useState(false);
   const { userid } = useParams();
+  const memberId = useSelector((state) => state.islogin.memberId);
+
+  useEffect(() => {
+    userid === memberId ? setIsMe(true) : setIsMe(false);
+  }, []);
 
   return (
     <div>

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { ReactComponent as ProfileImg } from '../assets/defaultImg.svg';
 import { ReactComponent as Setting } from '../assets/settingsIcon.svg';
@@ -105,17 +105,14 @@ const ProfileCard = ({
 }) => {
   /* 더미 데이터 */
   const isMe = true;
+  const { userid } = useParams();
 
   return (
     <div>
       <ProfileWrap className="card sm">
         <InformWrap>
           {image ? (
-            <img
-              className="img_profile"
-              src={image}
-              alt="프로필 이미지"
-            />
+            <img className="img_profile" src={image} alt="프로필 이미지" />
           ) : (
             <ProfileImg className="img_profile" />
           )}
@@ -126,7 +123,7 @@ const ProfileCard = ({
           {/* 자기 자신 여부에 따라 표시 아이콘 달라짐 */}
           {isMe ? (
             <div className="icon">
-              <Link to="/userid/edit">
+              <Link to={`/profile/${userid}/edit`}>
                 <Setting className="setting" />
               </Link>
             </div>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -4,19 +4,21 @@ import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import ProfileCard from '../components/ProfileCard';
 import ProfileContent from '../components/ProfileContent';
+import { useParams } from 'react-router-dom';
 
 const ProfileWrap = styled.div`
   display: flex;
 `;
 
 const Profile = () => {
+  const { userid } = useParams();
   const [user, setUser] = useState(null);
   const [match, setMatch] = useState(null);
   const [story, setStory] = useState(null);
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/api/members/3`, {
+      .get(`${API_URL}/api/members/${userid}`, {
         // ngrok get cors 해결용
         headers: {
           'ngrok-skip-browser-warning': '69420',
@@ -24,7 +26,7 @@ const Profile = () => {
       })
       .then((res) => setUser(res.data.data));
     axios
-      .get(`${API_URL}/api/members/3/matches`, {
+      .get(`${API_URL}/api/members/${userid}/matches`, {
         // ngrok get cors 해결용
         headers: {
           'ngrok-skip-browser-warning': '69420',
@@ -32,7 +34,7 @@ const Profile = () => {
       })
       .then((res) => setMatch(res.data.data));
     axios
-      .get(`${API_URL}/api/members/3/boards`, {
+      .get(`${API_URL}/api/members/${userid}/boards`, {
         // ngrok get cors 해결용
         headers: {
           'ngrok-skip-browser-warning': '69420',

--- a/client/src/pages/ProfileEdit.jsx
+++ b/client/src/pages/ProfileEdit.jsx
@@ -6,7 +6,7 @@ import InputWrap from '../components/InputWrap';
 import gameList from '../data/gameList.json';
 import axios from 'axios';
 import { API_URL } from '../data/apiUrl';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 const ContentWrap = styled.div`
   margin: 24px 0;
@@ -116,6 +116,7 @@ const BioWrap = styled.div`
 `;
 
 const ProfileEdit = () => {
+  const { userid } = useParams();
   const [user, setUser] = useState(null);
   const [nickname, setNickname] = useState('');
   const [fileName, setFileName] = useState('이미지 파일을 선택하세요');
@@ -174,7 +175,7 @@ const ProfileEdit = () => {
     }
 
     axios
-      .patch(`${API_URL}/api/members/3`, formData, {
+      .patch(`${API_URL}/api/members/${userid}`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
           Authorization: `Bearer ${ACCESS_TOKEN}`,
@@ -185,7 +186,7 @@ const ProfileEdit = () => {
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/api/members/3`, {
+      .get(`${API_URL}/api/members/${userid}`, {
         // ngrok get cors 해결용
         headers: {
           'ngrok-skip-browser-warning': '69420',

--- a/client/src/pages/ProfileEdit.jsx
+++ b/client/src/pages/ProfileEdit.jsx
@@ -150,8 +150,6 @@ const ProfileEdit = () => {
     [checkedGame]
   );
 
-  console.log(checkedGame);
-
   const handleBio = (e) => {
     setUser({ ...user, introduction: e.target.value });
   };


### PR DESCRIPTION
## 작업개요
- Profile 관련 페이지 API 및 url 수정

## worklog
- Profile과 연관된 페이지들의 API와 url을 수정했습니다. (특정 유저를 지정해서 API 호출을 하는게 아닌, 파라미터 값을 받아서 해당 유저의 프로필로 들어갈 수 있도록) 🍒🍒🍒이제 여러분도 프로필 이미지, 닉네임, 주로하는 게임, 소개말 등을 변경할 수 있습니다!!!!!🍒🍒🍒
- 내 프로필인지, 남의 프로필인지에 따라 그려지는 화면이 다르기 때문에 나인지 여부를 확인하는 로직을 수정했습니다.

## trouble shooting & 어려웠던 점
- 라우터 경로 작성했을 초반에는 문제가 없을거라 생각했는데 `userid`이든 `boardid`이든 똑같이 id값을 받아와서 사용하는거라 `/3/edit` 경로가 매칭하기 수정 경로로 이어지더라구요 저는 유저 정보 수정으로 진입하길 원했는데 🫠 때문에 유저 프로필과 관련된 링크는 전부 앞에 `/profile`을 붙이도록 수정했습니다!