### PR TITLE
[feat/fe-profilePagination] Profile Content pagination

### DIFF
--- a/client/src/components/Pagination.jsx
+++ b/client/src/components/Pagination.jsx
@@ -1,6 +1,7 @@
-import styled from "styled-components";
-import { ReactComponent as ArrowBack } from "../assets/arrowBack.svg";
-import { ReactComponent as ArrowForward } from "../assets/arrowForward.svg";
+import { useState } from 'react';
+import styled from 'styled-components';
+import { ReactComponent as ArrowBack } from '../assets/arrowBack.svg';
+import { ReactComponent as ArrowForward } from '../assets/arrowForward.svg';
 
 const PageWrap = styled.div`
   display: flex;
@@ -21,37 +22,258 @@ const PageWrap = styled.div`
   }
 `;
 
-const Pagination = () => {
-  const isPage1 = false;
-  const isPage2 = false;
-  const isPage3 = true;
-  const isPage4 = false;
-  const isPage5 = false;
+const Pagination = ({
+  isMatch,
+  matchPage,
+  setMatchPage,
+  matchPageInfo,
+  storyPage,
+  setStoryPage,
+  storyPageInfo,
+}) => {
+  const [matchFirstPage, setMatchFirstPage] = useState(matchPage);
+  const matchTotalPage = matchPageInfo.totalPages;
+  const matchFirstNum = matchFirstPage - (matchFirstPage % 8) + 1;
+
+  const [storyFirstPage, setStoryFirstPage] = useState(storyPage);
+  const storyTotalPage = storyPageInfo.totalPages;
+  const storyFirstNum = storyFirstPage - (storyFirstPage % 8) + 1;
+
+  const [isMatchPage1, setIsMatchPage1] = useState(true);
+  const [isMatchPage2, setIsMatchPage2] = useState(false);
+  const [isMatchPage3, setIsMatchPage3] = useState(false);
+  const [isMatchPage4, setIsMatchPage4] = useState(false);
+  const [isMatchPage5, setIsMatchPage5] = useState(false);
+
+  const [isStoryPage1, setIsStoryPage1] = useState(true);
+  const [isStoryPage2, setIsStoryPage2] = useState(false);
+  const [isStoryPage3, setIsStoryPage3] = useState(false);
+  const [isStoryPage4, setIsStoryPage4] = useState(false);
+  const [isStoryPage5, setIsStoryPage5] = useState(false);
 
   return (
     <PageWrap>
-      {/* 하드코딩 정보 수정 필요 */}
-      <a className="page_content" href="none">
-        <ArrowBack />
-      </a>
-      <a className={"page_content" + (isPage1 ? " active" : "")} href="none">
-        1
-      </a>
-      <a className={"page_content" + (isPage2 ? " active" : "")} href="none">
-        2
-      </a>
-      <a className={"page_content" + (isPage3 ? " active" : "")} href="none">
-        3
-      </a>
-      <a className={"page_content" + (isPage4 ? " active" : "")} href="none">
-        4
-      </a>
-      <a className={"page_content" + (isPage5 ? " active" : "")} href="none">
-        5
-      </a>
-      <a className="page_content" href="none">
-        <ArrowForward />
-      </a>
+      {isMatch ? (
+        <>
+          {matchTotalPage > 5 ? (
+            <button
+              className="page_content"
+              onClick={() => {
+                setMatchPage(matchPage - 1);
+                setMatchFirstPage(matchPage - 2);
+                setIsMatchPage1(true);
+                setIsMatchPage2(false);
+                setIsMatchPage3(false);
+                setIsMatchPage4(false);
+                setIsMatchPage5(false);
+              }}
+            >
+              <ArrowBack />
+            </button>
+          ) : null}
+          {matchTotalPage >= matchFirstNum ? (
+            <button
+              className={'page_content' + (isMatchPage1 ? ' active' : '')}
+              onClick={() => {
+                setMatchPage(matchFirstNum);
+                setIsMatchPage1(true);
+                setIsMatchPage2(false);
+                setIsMatchPage3(false);
+                setIsMatchPage4(false);
+                setIsMatchPage5(false);
+              }}
+            >
+              {matchFirstNum}
+            </button>
+          ) : null}
+          {matchTotalPage >= matchFirstNum + 1 ? (
+            <button
+              className={'page_content' + (isMatchPage2 ? ' active' : '')}
+              onClick={() => {
+                setMatchPage(matchFirstNum + 1);
+                setIsMatchPage1(false);
+                setIsMatchPage2(true);
+                setIsMatchPage3(false);
+                setIsMatchPage4(false);
+                setIsMatchPage5(false);
+              }}
+            >
+              {matchFirstNum + 1}
+            </button>
+          ) : null}
+          {matchTotalPage >= matchFirstNum + 2 ? (
+            <button
+              className={'page_content' + (isMatchPage3 ? ' active' : '')}
+              onClick={() => {
+                setMatchPage(matchFirstNum + 2);
+                setIsMatchPage1(false);
+                setIsMatchPage2(false);
+                setIsMatchPage3(true);
+                setIsMatchPage4(false);
+                setIsMatchPage5(false);
+              }}
+            >
+              {matchFirstNum + 2}
+            </button>
+          ) : null}
+          {matchTotalPage >= matchFirstNum + 3 ? (
+            <button
+              className={'page_content' + (isMatchPage4 ? ' active' : '')}
+              onClick={() => {
+                setMatchPage(matchFirstNum + 3);
+                setIsMatchPage1(false);
+                setIsMatchPage2(false);
+                setIsMatchPage3(false);
+                setIsMatchPage4(true);
+                setIsMatchPage5(false);
+              }}
+            >
+              {matchFirstNum + 3}
+            </button>
+          ) : null}
+          {matchTotalPage >= matchFirstNum + 4 ? (
+            <button
+              className={'page_content' + (isMatchPage5 ? ' active' : '')}
+              onClick={() => {
+                setMatchPage(matchFirstNum + 4);
+                setIsMatchPage1(false);
+                setIsMatchPage2(false);
+                setIsMatchPage3(false);
+                setIsMatchPage4(false);
+                setIsMatchPage5(true);
+              }}
+            >
+              {matchFirstNum + 4}
+            </button>
+          ) : null}
+          {matchTotalPage > 5 ? (
+            <button
+              className="page_content"
+              onClick={() => {
+                setMatchPage(matchPage + 1);
+                setMatchFirstPage(matchPage);
+                setIsMatchPage1(true);
+                setIsMatchPage2(false);
+                setIsMatchPage3(false);
+                setIsMatchPage4(false);
+                setIsMatchPage5(false);
+              }}
+            >
+              <ArrowForward />
+            </button>
+          ) : null}
+        </>
+      ) : (
+        <>
+          {storyTotalPage > 5 ? (
+            <button
+              className="page_content"
+              onClick={() => {
+                setStoryPage(storyPage - 1);
+                setStoryFirstPage(storyPage - 2);
+                setIsStoryPage1(true);
+                setIsStoryPage2(false);
+                setIsStoryPage3(false);
+                setIsStoryPage4(false);
+                setIsStoryPage5(false);
+              }}
+            >
+              <ArrowBack />
+            </button>
+          ) : null}
+          {storyTotalPage >= storyFirstNum ? (
+            <button
+              className={'page_content' + (isStoryPage1 ? ' active' : '')}
+              onClick={() => {
+                setStoryPage(storyFirstNum);
+                setIsStoryPage1(true);
+                setIsStoryPage2(false);
+                setIsStoryPage3(false);
+                setIsStoryPage4(false);
+                setIsStoryPage5(false);
+              }}
+            >
+              {storyFirstNum}
+            </button>
+          ) : null}
+          {storyTotalPage >= storyFirstNum + 1 ? (
+            <button
+              className={'page_content' + (isStoryPage2 ? ' active' : '')}
+              onClick={() => {
+                setStoryPage(storyFirstNum + 1);
+                setIsStoryPage1(false);
+                setIsStoryPage2(true);
+                setIsStoryPage3(false);
+                setIsStoryPage4(false);
+                setIsStoryPage5(false);
+              }}
+            >
+              {storyFirstNum + 1}
+            </button>
+          ) : null}
+          {storyTotalPage >= storyFirstNum + 2 ? (
+            <button
+              className={'page_content' + (isStoryPage3 ? ' active' : '')}
+              onClick={() => {
+                setStoryPage(storyFirstNum + 2);
+                setIsStoryPage1(false);
+                setIsStoryPage2(false);
+                setIsStoryPage3(true);
+                setIsStoryPage4(false);
+                setIsStoryPage5(false);
+              }}
+            >
+              {storyFirstNum + 2}
+            </button>
+          ) : null}
+          {storyTotalPage >= storyFirstNum + 3 ? (
+            <button
+              className={'page_content' + (isStoryPage4 ? ' active' : '')}
+              onClick={() => {
+                setStoryPage(storyFirstNum + 3);
+                setIsStoryPage1(false);
+                setIsStoryPage2(false);
+                setIsStoryPage3(false);
+                setIsStoryPage4(true);
+                setIsStoryPage5(false);
+              }}
+            >
+              {storyFirstNum + 3}
+            </button>
+          ) : null}
+          {storyTotalPage >= storyFirstNum + 4 ? (
+            <button
+              className={'page_content' + (isStoryPage5 ? ' active' : '')}
+              onClick={() => {
+                setStoryPage(storyFirstNum + 4);
+                setIsStoryPage1(false);
+                setIsStoryPage2(false);
+                setIsStoryPage3(false);
+                setIsStoryPage4(false);
+                setIsStoryPage5(true);
+              }}
+            >
+              {storyFirstNum + 4}
+            </button>
+          ) : null}
+          {storyTotalPage > 5 ? (
+            <button
+              className="page_content"
+              onClick={() => {
+                setStoryPage(storyPage + 1);
+                setStoryFirstPage(storyPage);
+                setIsStoryPage1(true);
+                setIsStoryPage2(false);
+                setIsStoryPage3(false);
+                setIsStoryPage4(false);
+                setIsStoryPage5(false);
+              }}
+            >
+              <ArrowForward />
+            </button>
+          ) : null}
+        </>
+      )}
     </PageWrap>
   );
 };

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -1,11 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import styled from 'styled-components';
+import SinglePofileWrap from './SingleProfileWrap';
 import { ReactComponent as ProfileImg } from '../assets/defaultImg.svg';
 import { ReactComponent as Setting } from '../assets/settingsIcon.svg';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
-import { useState } from 'react';
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 const ProfileWrap = styled.div`
   width: var(--col-4);
@@ -24,6 +24,7 @@ const ProfileWrap = styled.div`
 
 const InformWrap = styled.div`
   display: flex;
+  justify-content: space-between;
   margin-bottom: 16px;
   .img_profile {
     width: 56px;
@@ -31,20 +32,7 @@ const InformWrap = styled.div`
     border-radius: 50%;
     margin-right: 16px;
   }
-  .name_content {
-    width: 100%;
-    margin: auto;
-  }
-  .nickname {
-    color: var(--white);
-    font-size: 18px;
-    font-weight: var(--font-weight-medium);
-  }
-  .identifier {
-    font-size: var(--font-body2-size);
-  }
   .icon {
-    margin-left: 16px;
     margin: auto 0;
   }
   .setting,
@@ -119,15 +107,7 @@ const ProfileCard = ({
     <div>
       <ProfileWrap className="card sm">
         <InformWrap>
-          {image ? (
-            <img className="img_profile" src={image} alt="프로필 이미지" />
-          ) : (
-            <ProfileImg className="img_profile" />
-          )}
-          <div className="name_content">
-            <div className="nickname">{nickname}</div>
-            <div className="identifier">{identifier}</div>
-          </div>
+          <SinglePofileWrap imgSize="big" imgSrc={image} name={nickname} subInfo={identifier} />
           {/* 자기 자신 여부에 따라 표시 아이콘 달라짐 */}
           {isMe ? (
             <div className="icon">

--- a/client/src/components/ProfileContent.jsx
+++ b/client/src/components/ProfileContent.jsx
@@ -24,7 +24,7 @@ const TabWrap = styled.div`
   }
 `;
 
-const ProfileContent = ({ matchBoards, userBoards }) => {
+const ProfileContent = () => {
   const [isMatch, setIsMatch] = useState(true);
   const [isStory, setIsStory] = useState(false);
 
@@ -51,12 +51,7 @@ const ProfileContent = ({ matchBoards, userBoards }) => {
           </li>
         </ul>
       </TabWrap>
-      <ProfileContentList
-        isMatch={isMatch}
-        isStory={isStory}
-        matchBoards={matchBoards}
-        userBoards={userBoards}
-      />
+      <ProfileContentList isMatch={isMatch} isStory={isStory} />
       <Pagination />
     </ContentWrap>
   );

--- a/client/src/components/ProfileContent.jsx
+++ b/client/src/components/ProfileContent.jsx
@@ -1,6 +1,5 @@
 import styled from 'styled-components';
 import ProfileContentList from './ProfileContentList';
-import Pagination from './Pagination';
 import { useState } from 'react';
 
 const ContentWrap = styled.div`
@@ -52,7 +51,6 @@ const ProfileContent = () => {
         </ul>
       </TabWrap>
       <ProfileContentList isMatch={isMatch} isStory={isStory} />
-      <Pagination />
     </ContentWrap>
   );
 };

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
 import { ReactComponent as Comment } from '../assets/sms.svg';
+import matchGame from '../util/matchGame';
 
 const ListWrap = styled.div`
   li {
@@ -80,7 +81,11 @@ const ProfileContentList = ({ isMatch, isStory, matchBoards, userBoards }) => {
           ? matchBoards.map((match) => (
               <li key={match.id}>
                 <div className="game_container">
-                  <img className="game_icon" src={''} alt="게임 아이콘" />
+                  <img
+                    className="game_icon"
+                    src={matchGame(match.game).image}
+                    alt="게임 아이콘"
+                  />
                 </div>
                 <div className="content_container match">
                   <div className="content_title">{match.title}</div>

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -82,24 +82,23 @@ const ProfileContentList = ({ isMatch, isStory }) => {
   const { userid } = useParams();
   const [match, setMatch] = useState(null);
   const [story, setStory] = useState(null);
+  const [page, setPage] = useState(1);
+  const [matchPageInfo, setMatchPageInfo] = useState(null);
+  const [storyPageInfo, setStoryPageInfo] = useState(null);
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/api/members/${userid}/matches`, {
-        // ngrok get cors 해결용
-        headers: {
-          'ngrok-skip-browser-warning': '69420',
-        },
-      })
-      .then((res) => setMatch(res.data.data));
+      .get(`${API_URL}/api/members/${userid}/matches?page=${page}`)
+      .then((res) => {
+        setMatch(res.data.data);
+        setMatchPageInfo(res.data.pageInfo);
+      });
     axios
-      .get(`${API_URL}/api/members/${userid}/boards`, {
-        // ngrok get cors 해결용
-        headers: {
-          'ngrok-skip-browser-warning': '69420',
-        },
-      })
-      .then((res) => setStory(res.data.data));
+      .get(`${API_URL}/api/members/${userid}/boards?page=${page}`)
+      .then((res) => {
+        setStory(res.data.data);
+        setStoryPageInfo(res.data.pageInfo);
+      });
   }, []);
 
   if (match && story) {
@@ -163,7 +162,13 @@ const ProfileContentList = ({ isMatch, isStory }) => {
               : null}
           </ul>
         </ListWrap>
-        <Pagination />
+        <Pagination
+          isMatch={isMatch}
+          page={page}
+          setPage={setPage}
+          matchPageInfo={matchPageInfo}
+          storyPageInfo={storyPageInfo}
+        />
       </>
     );
   } else return null;

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
 import { ReactComponent as Comment } from '../assets/sms.svg';
+import Pagination from './Pagination';
 import axios from 'axios';
 import { API_URL } from '../data/apiUrl';
 import matchGame from '../util/matchGame';
@@ -99,68 +100,71 @@ const ProfileContentList = ({ isMatch, isStory }) => {
         },
       })
       .then((res) => setStory(res.data.data));
-  });
+  }, []);
 
   if (match && story) {
     return (
-      <ListWrap>
-        <ul>
-          {isMatch
-            ? match.map((match) => (
-                <li key={match.id}>
-                  <div className="game_container">
-                    <img
-                      className="game_icon"
-                      src={matchGame(match.game).image}
-                      alt="게임 아이콘"
-                    />
-                  </div>
-                  <div className="content_container match">
-                    <a href={`/${match.id}/detail`}>
-                      <div className="content_title">{match.title}</div>
-                    </a>
-                    <div className="content_date">
-                      {new Date(match.createdAt).toLocaleString()}
+      <>
+        <ListWrap>
+          <ul>
+            {isMatch
+              ? match.map((match) => (
+                  <li key={match.id}>
+                    <div className="game_container">
+                      <img
+                        className="game_icon"
+                        src={matchGame(match.game).image}
+                        alt="게임 아이콘"
+                      />
                     </div>
-                  </div>
-                </li>
-              ))
-            : null}
-          {isStory
-            ? story.map((story) => (
-                <li key={story.id}>
-                  <div className="content_container story">
-                    <a href={`/story/${userid}/${story.id}`}>
-                      <div className="content_title">{story.content}</div>
-                    </a>
-                    <div className="content_date">
-                      {new Date(story.createdAt).toLocaleString()}
+                    <div className="content_container match">
+                      <a href={`/${match.id}/detail`}>
+                        <div className="content_title">{match.title}</div>
+                      </a>
+                      <div className="content_date">
+                        {new Date(match.createdAt).toLocaleString()}
+                      </div>
                     </div>
-                    <div className="content_count">
-                      {story.likeCount ? (
-                        <div className="content_like">
-                          <Heart width="10px" />
-                          <span>{story.likeCount}</span>
-                        </div>
-                      ) : null}
-                      {story.commentCount ? (
-                        <div className="content_comment">
-                          <Comment width="10px" />
-                          <span>{story.commentCount}</span>
-                        </div>
-                      ) : null}
+                  </li>
+                ))
+              : null}
+            {isStory
+              ? story.map((story) => (
+                  <li key={story.id}>
+                    <div className="content_container story">
+                      <a href={`/story/${userid}/${story.id}`}>
+                        <div className="content_title">{story.content}</div>
+                      </a>
+                      <div className="content_date">
+                        {new Date(story.createdAt).toLocaleString()}
+                      </div>
+                      <div className="content_count">
+                        {story.likeCount ? (
+                          <div className="content_like">
+                            <Heart width="10px" />
+                            <span>{story.likeCount}</span>
+                          </div>
+                        ) : null}
+                        {story.commentCount ? (
+                          <div className="content_comment">
+                            <Comment width="10px" />
+                            <span>{story.commentCount}</span>
+                          </div>
+                        ) : null}
+                      </div>
                     </div>
-                  </div>
-                  {story.uploadFileName ? (
-                    <div className="image_container">
-                      <img src={story.uploadFileName} alt="스토리 이미지" />
-                    </div>
-                  ) : null}
-                </li>
-              ))
-            : null}
-        </ul>
-      </ListWrap>
+                    {story.uploadFileName ? (
+                      <div className="image_container">
+                        <img src={story.uploadFileName} alt="스토리 이미지" />
+                      </div>
+                    ) : null}
+                  </li>
+                ))
+              : null}
+          </ul>
+        </ListWrap>
+        <Pagination />
+      </>
     );
   } else return null;
 };

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -1,7 +1,10 @@
+import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
 import { ReactComponent as Comment } from '../assets/sms.svg';
+import axios from 'axios';
+import { API_URL } from '../data/apiUrl';
 import matchGame from '../util/matchGame';
 
 const ListWrap = styled.div`
@@ -74,68 +77,92 @@ const ListWrap = styled.div`
   }
 `;
 
-const ProfileContentList = ({ isMatch, isStory, matchBoards, userBoards }) => {
+const ProfileContentList = ({ isMatch, isStory }) => {
   const { userid } = useParams();
-  return (
-    <ListWrap>
-      <ul>
-        {isMatch
-          ? matchBoards.map((match) => (
-              <li key={match.id}>
-                <div className="game_container">
-                  <img
-                    className="game_icon"
-                    src={matchGame(match.game).image}
-                    alt="게임 아이콘"
-                  />
-                </div>
-                <div className="content_container match">
-                  <a href={`/${match.id}/detail`}>
-                    <div className="content_title">{match.title}</div>
-                  </a>
-                  <div className="content_date">
-                    {new Date(match.createdAt).toLocaleString()}
+  const [match, setMatch] = useState(null);
+  const [story, setStory] = useState(null);
+
+  useEffect(() => {
+    axios
+      .get(`${API_URL}/api/members/${userid}/matches`, {
+        // ngrok get cors 해결용
+        headers: {
+          'ngrok-skip-browser-warning': '69420',
+        },
+      })
+      .then((res) => setMatch(res.data.data));
+    axios
+      .get(`${API_URL}/api/members/${userid}/boards`, {
+        // ngrok get cors 해결용
+        headers: {
+          'ngrok-skip-browser-warning': '69420',
+        },
+      })
+      .then((res) => setStory(res.data.data));
+  });
+
+  if (match && story) {
+    return (
+      <ListWrap>
+        <ul>
+          {isMatch
+            ? match.map((match) => (
+                <li key={match.id}>
+                  <div className="game_container">
+                    <img
+                      className="game_icon"
+                      src={matchGame(match.game).image}
+                      alt="게임 아이콘"
+                    />
                   </div>
-                </div>
-              </li>
-            ))
-          : null}
-        {isStory
-          ? userBoards.map((story) => (
-              <li key={story.id}>
-                <div className="content_container story">
-                  <a href={`/story/${userid}/${story.id}`}>
-                    <div className="content_title">{story.content}</div>
-                  </a>
-                  <div className="content_date">
-                    {new Date(story.createdAt).toLocaleString()}
+                  <div className="content_container match">
+                    <a href={`/${match.id}/detail`}>
+                      <div className="content_title">{match.title}</div>
+                    </a>
+                    <div className="content_date">
+                      {new Date(match.createdAt).toLocaleString()}
+                    </div>
                   </div>
-                  <div className="content_count">
-                    {story.likeCount ? (
-                      <div className="content_like">
-                        <Heart width="10px" />
-                        <span>{story.likeCount}</span>
-                      </div>
-                    ) : null}
-                    {story.commentCount ? (
-                      <div className="content_comment">
-                        <Comment width="10px" />
-                        <span>{story.commentCount}</span>
-                      </div>
-                    ) : null}
+                </li>
+              ))
+            : null}
+          {isStory
+            ? story.map((story) => (
+                <li key={story.id}>
+                  <div className="content_container story">
+                    <a href={`/story/${userid}/${story.id}`}>
+                      <div className="content_title">{story.content}</div>
+                    </a>
+                    <div className="content_date">
+                      {new Date(story.createdAt).toLocaleString()}
+                    </div>
+                    <div className="content_count">
+                      {story.likeCount ? (
+                        <div className="content_like">
+                          <Heart width="10px" />
+                          <span>{story.likeCount}</span>
+                        </div>
+                      ) : null}
+                      {story.commentCount ? (
+                        <div className="content_comment">
+                          <Comment width="10px" />
+                          <span>{story.commentCount}</span>
+                        </div>
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-                {story.uploadFileName ? (
-                  <div className="image_container">
-                    <img src={story.uploadFileName} alt="스토리 이미지" />
-                  </div>
-                ) : null}
-              </li>
-            ))
-          : null}
-      </ul>
-    </ListWrap>
-  );
+                  {story.uploadFileName ? (
+                    <div className="image_container">
+                      <img src={story.uploadFileName} alt="스토리 이미지" />
+                    </div>
+                  ) : null}
+                </li>
+              ))
+            : null}
+        </ul>
+      </ListWrap>
+    );
+  } else return null;
 };
 
 export default ProfileContentList;

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -82,24 +82,28 @@ const ProfileContentList = ({ isMatch, isStory }) => {
   const { userid } = useParams();
   const [match, setMatch] = useState(null);
   const [story, setStory] = useState(null);
-  const [page, setPage] = useState(1);
+  const [matchPage, setMatchPage] = useState(1);
+  const [storyPage, setStoryPage] = useState(1);
   const [matchPageInfo, setMatchPageInfo] = useState(null);
   const [storyPageInfo, setStoryPageInfo] = useState(null);
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/api/members/${userid}/matches?page=${page}`)
+      .get(`${API_URL}/api/members/${userid}/matches?page=${matchPage}`)
       .then((res) => {
         setMatch(res.data.data);
         setMatchPageInfo(res.data.pageInfo);
       });
+  }, [matchPage]);
+
+  useEffect(() => {
     axios
-      .get(`${API_URL}/api/members/${userid}/boards?page=${page}`)
+      .get(`${API_URL}/api/members/${userid}/boards?page=${storyPage}`)
       .then((res) => {
         setStory(res.data.data);
         setStoryPageInfo(res.data.pageInfo);
       });
-  }, []);
+  }, [storyPage]);
 
   if (match && story) {
     return (
@@ -164,9 +168,11 @@ const ProfileContentList = ({ isMatch, isStory }) => {
         </ListWrap>
         <Pagination
           isMatch={isMatch}
-          page={page}
-          setPage={setPage}
+          matchPage={matchPage}
+          setMatchPage={setMatchPage}
           matchPageInfo={matchPageInfo}
+          storyPage={storyPage}
+          setStoryPage={setStoryPage}
           storyPageInfo={storyPageInfo}
         />
       </>

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
 import { ReactComponent as Comment } from '../assets/sms.svg';
-import Pagination from './Pagination';
+import ProfilePagination from './ProfilePagination';
 import axios from 'axios';
 import { API_URL } from '../data/apiUrl';
 import matchGame from '../util/matchGame';
@@ -75,6 +75,10 @@ const ListWrap = styled.div`
         object-fit: cover;
       }
     }
+    .content_none {
+      width: 100%;
+      text-align: center;
+    }
   }
 `;
 
@@ -110,8 +114,9 @@ const ProfileContentList = ({ isMatch, isStory }) => {
       <>
         <ListWrap>
           <ul>
-            {isMatch
-              ? match.map((match) => (
+            {isMatch ? (
+              match.length > 0 ? (
+                match.map((match) => (
                   <li key={match.id}>
                     <div className="game_container">
                       <img
@@ -130,9 +135,17 @@ const ProfileContentList = ({ isMatch, isStory }) => {
                     </div>
                   </li>
                 ))
-              : null}
-            {isStory
-              ? story.map((story) => (
+              ) : (
+                <li>
+                  <div className="content_none">
+                    작성된 매칭하기가 없습니다.
+                  </div>
+                </li>
+              )
+            ) : null}
+            {isStory ? (
+              story.length > 0 ? (
+                story.map((story) => (
                   <li key={story.id}>
                     <div className="content_container story">
                       <a href={`/story/${userid}/${story.id}`}>
@@ -163,10 +176,15 @@ const ProfileContentList = ({ isMatch, isStory }) => {
                     ) : null}
                   </li>
                 ))
-              : null}
+              ) : (
+                <li>
+                  <div className="content_none">작성된 스토리가 없습니다.</div>
+                </li>
+              )
+            ) : null}
           </ul>
         </ListWrap>
-        <Pagination
+        <ProfilePagination
           isMatch={isMatch}
           matchPage={matchPage}
           setMatchPage={setMatchPage}

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -1,3 +1,4 @@
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { ReactComponent as Heart } from '../assets/heartIcon.svg';
 import { ReactComponent as Comment } from '../assets/sms.svg';
@@ -74,6 +75,7 @@ const ListWrap = styled.div`
 `;
 
 const ProfileContentList = ({ isMatch, isStory, matchBoards, userBoards }) => {
+  const { userid } = useParams();
   return (
     <ListWrap>
       <ul>
@@ -88,7 +90,9 @@ const ProfileContentList = ({ isMatch, isStory, matchBoards, userBoards }) => {
                   />
                 </div>
                 <div className="content_container match">
-                  <div className="content_title">{match.title}</div>
+                  <a href={`/${match.id}/detail`}>
+                    <div className="content_title">{match.title}</div>
+                  </a>
                   <div className="content_date">
                     {new Date(match.createdAt).toLocaleString()}
                   </div>
@@ -100,7 +104,9 @@ const ProfileContentList = ({ isMatch, isStory, matchBoards, userBoards }) => {
           ? userBoards.map((story) => (
               <li key={story.id}>
                 <div className="content_container story">
-                  <div className="content_title">{story.content}</div>
+                  <a href={`/story/${userid}/${story.id}`}>
+                    <div className="content_title">{story.content}</div>
+                  </a>
                   <div className="content_date">
                     {new Date(story.createdAt).toLocaleString()}
                   </div>

--- a/client/src/components/ProfilePagination.jsx
+++ b/client/src/components/ProfilePagination.jsx
@@ -22,7 +22,7 @@ const PageWrap = styled.div`
   }
 `;
 
-const Pagination = ({
+const ProfilePagination = ({
   isMatch,
   matchPage,
   setMatchPage,
@@ -278,4 +278,4 @@ const Pagination = ({
   );
 };
 
-export default Pagination;
+export default ProfilePagination;

--- a/client/src/data/apiUrl.js
+++ b/client/src/data/apiUrl.js
@@ -1,1 +1,1 @@
-export const API_URL = `https://1e36-14-63-98-43.jp.ngrok.io`;
+export const API_URL = `https://port-0-seb41-main-033-1jx7m2gld2o3uit.gksl2.cloudtype.app`;

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -16,12 +16,7 @@ const Profile = () => {
 
   useEffect(() => {
     axios
-      .get(`${API_URL}/api/members/${userid}`, {
-        // ngrok get cors 해결용
-        headers: {
-          'ngrok-skip-browser-warning': '69420',
-        },
-      })
+      .get(`${API_URL}/api/members/${userid}`)
       .then((res) => setUser(res.data.data));
   }, []);
 

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -13,8 +13,6 @@ const ProfileWrap = styled.div`
 const Profile = () => {
   const { userid } = useParams();
   const [user, setUser] = useState(null);
-  const [match, setMatch] = useState(null);
-  const [story, setStory] = useState(null);
 
   useEffect(() => {
     axios
@@ -25,25 +23,9 @@ const Profile = () => {
         },
       })
       .then((res) => setUser(res.data.data));
-    axios
-      .get(`${API_URL}/api/members/${userid}/matches`, {
-        // ngrok get cors 해결용
-        headers: {
-          'ngrok-skip-browser-warning': '69420',
-        },
-      })
-      .then((res) => setMatch(res.data.data));
-    axios
-      .get(`${API_URL}/api/members/${userid}/boards`, {
-        // ngrok get cors 해결용
-        headers: {
-          'ngrok-skip-browser-warning': '69420',
-        },
-      })
-      .then((res) => setStory(res.data.data));
   }, []);
 
-  if (user && match && story) {
+  if (user) {
     return (
       <ProfileWrap>
         <ProfileCard
@@ -56,7 +38,7 @@ const Profile = () => {
           games={user.games}
           introduction={user.introduction}
         />
-        <ProfileContent matchBoards={match} userBoards={story} />
+        <ProfileContent />
       </ProfileWrap>
     );
   } else {


### PR DESCRIPTION
## 작업개요
- Profile page (Profile Content component) 페이지네이션
- 그 외 기타 Profile 페이지 관련 작업

## worklog
- Profile Content List에서 매칭글 클릭 시 작성한 매칭글의 게임 아이콘이 표시되도록 변경했습니다. (이걸 이제 발견한 제 자신이 아주 놀라와요...)
> ### 눈에 잘 안띄지만 아무튼 게임 아이콘 맞습니다,,
>![엣헴](https://user-images.githubusercontent.com/111413253/213692260-e8b9b34a-35f6-4be9-b49b-26e0844bed9f.png)
- Profile Content List 컴포넌트에서 각 게시물 상세보기로 넘어갈 수 있도록 url을 연결했습니다.
> ### 프로필에서 게시물 상세보기로
>![허억](https://user-images.githubusercontent.com/111413253/213692468-33602910-ffb3-4ecb-b00f-29b8975a57d5.gif)
- Profile Card 컴포넌트의 프로필, 닉네임, 아이디 부분을 Single Profile Wrap 컴포넌트로 변경했습니다.
- **마참내!** Profile Content 컴포넌트 페이지네이션
> [https://velog.io/@ahsy92/React-Pagination-구현하기](https://velog.io/@ahsy92/React-Pagination-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)
여러 코드들을 참고해서.. 우리 서비스에 필요한 정보 값만 사용해서 구현해보았습니다. 우리 서버의 경우 API 자체에서 totalPages를 보내주기 때문에 참고한 코드처럼 전체 페이지 값을 구하거나 할 필요가 없었어요. 백엔드 짱 👍🏻
총 페이지가 5페이지 이내일 경우, 숫자 양 옆의 < > 모양이 표시되지 않도록 설정했기 때문에 현재 시연 화면에서는 양 옆 화살표가 보이지 않습니다. 총 페이지가 6개 이상이면 아마 보이게 되지 않을까요…? 🤔 (게시물 40개 넘게 작성할 자신이 없어서 못했는데 아무튼 테스트 필요)
또 최대 페이지 이상의 페이지는 출력되지 않도록 했습니당!
> ### 페이지네이숀
>![허거덩](https://user-images.githubusercontent.com/111413253/213693133-f4fd665b-f2c5-4ffa-a262-79f4355924ba.gif)
- 추가 작업: 사용자가 아무런 게시물을 작성하지 않았을 때 보이는 화면을 다르게 만들었습니다.
> ### 게시물 없읍니다.
>![아하](https://user-images.githubusercontent.com/111413253/213699830-b037487a-974a-44fa-ad3e-7bdd199ab00d.png)

## trouble shooting & 어려웠던 점
- 우리 서비스 페이지네이션의 특이점..!!!
한 컴포넌트에서 탭으로 보여지는 값이 달라지고, 각 탭마다 따로 페이지네이션이 들어가야 했기 때문에 `useState`로 선언한 변수가 아주 많아졌습니다(…)
매칭글과 스토리 탭의 page를 공유하게 될 경우, 매칭글에서 2페이지를 클릭했다면 스토리에서도 똑같이 2페이지가 보여지기 때문에 변수의 분리가 필요했어요 🥹
또, 현재 클릭한 버튼에 css를 주기 위해 또 상태값을 사용해야 했고.. (이건 더 줄일 수 있는데 제가 멍청해서 방법을 모르는 걸지도), 해당 상태가 매칭글, 스토리 모두에게 공유되는 값이라면 또 원하지 않는 화면을 보여줘서 ㅋㅋㅋㅋㅋ 어쩔 수 없이 변수를 잔뜩 분리하게 되었습니다... Pagination 컴포넌트에만 선언된 변수가 무려 10몇 개.. 작성하면서도 이게 맞는걸까 엄청 고민한,,ㅋㅋㅋㅋ
결과적으로 제가 작성한 페이지네이션은 엄청난 하드코딩의 산물입니다..🫠