### PR TITLE
[feat/fe-storyInfScroll] 스토리 무한스크롤 구현

### DIFF
--- a/client/src/components/Loading.jsx
+++ b/client/src/components/Loading.jsx
@@ -1,4 +1,6 @@
 import styled from "styled-components";
+import React from "react";
+import { forwardRef } from "react";
 
 const Wrap = styled.div`
 	padding: 48px 0;
@@ -7,7 +9,7 @@ const Wrap = styled.div`
 const Spinner = styled.div`
 	width: 60px;
 	height: 60px;
-	margin: 24px auto;
+	margin: 60px auto;
 	border: 3px solid var(--input-color);
 	border-radius: 50%;
 	border-top-color: var(--primary-color);
@@ -23,11 +25,16 @@ const Spinner = styled.div`
 	}
 `;
 
-const Loading = () => {
+// const Loading = forwardRef((props, ref) => {
+// 	return <Spinner ref={ref} />;
+// });
+
+const Loading = forwardRef((props, ref) => {
 	return (
-		<Wrap>
-			<Spinner />
-		</Wrap>
+		<>
+			<Spinner ref={ref} />
+		</>
 	);
-};
+});
+
 export default Loading;

--- a/client/src/pages/Story.jsx
+++ b/client/src/pages/Story.jsx
@@ -68,12 +68,10 @@ const Story = () => {
 	//페이지 로딩 state
 	const [page, setPage] = useState(0);
 	const [isLoading, setIsLoading] = useState(false);
-	//const pageEndPoint = createRef(); //에러...
 	const pageEndPoint = useRef();
 	//페이지 증가 함수
 	const addPage = () => {
 		setPage((prevPage) => {
-			//console.log(prevPage);
 			return prevPage + 1;
 		});
 	};
@@ -116,23 +114,6 @@ const Story = () => {
 			observer.observe(pageEndPoint.current);
 		}
 	}, [isLoading]);
-
-	//이전 버전
-	// useEffect(() => {
-	// 	axios
-	// 		.get(`${API_URL}/api/boards?page=1`, {
-	// 			// headers: {
-	// 			// 	// "ngrok-skip-browser-warning": "69420",
-	// 			// 	Authorization: `Bearer ${accessToken}`,
-	// 			// },
-	// 		})
-	// 		.then((res) => {
-	// 			setStoryData([...storyData, ...res.data.data]);
-	// 		})
-	// 		.catch((err) => {
-	// 			console.log(err);
-	// 		});
-	// }, []);
 
 	const handleWriteFBtnOnClick = () => {
 		navigate(`/storywrite`);

--- a/client/src/pages/Story.jsx
+++ b/client/src/pages/Story.jsx
@@ -2,11 +2,37 @@ import styled from "styled-components";
 import SearchBar from "./../components/SearchBar";
 import StorySingle from "../components/StorySingle";
 import WriteFloatButton from "../components/WriteFloatButton";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, createRef } from "react";
 import axios from "axios";
 import { API_URL } from "../data/apiUrl";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
+import Loading from "../components/Loading";
+
+const Wrap = styled.div`
+	.loadingObserver {
+		> div {
+			width: 100%;
+			height: 140px;
+			margin-bottom: 24px;
+			border-radius: var(--border-radius-lg);
+			background: var(--darkgrey1);
+			animation: loading_skeleton 1.2s linear infinite;
+		}
+	}
+
+	@keyframes loading_skeleton {
+		0% {
+			background: var(--darkgrey1);
+		}
+		50% {
+			background: var(--darkgrey2);
+		}
+		100% {
+			background: var(--darkgrey1);
+		}
+	}
+`;
 
 const TitleWrap = styled.div`
 	display: flex;
@@ -34,38 +60,107 @@ const Story = () => {
 	const accessToken = loginInfo.accessToken;
 	const navigate = useNavigate();
 	const [storyData, setStoryData] = useState([]);
-	useEffect(() => {
-		axios
-			.get(`${API_URL}/api/boards?page=1`, {
+
+	//고도화 필요
+	//두 번씩 로딩되는게 react.strictMode 때문인가... 일단 보류
+	//총 페이지 제한해서 마지막 페이지면 로딩 안보이게 하기
+
+	//페이지 로딩 state
+	const [page, setPage] = useState(0);
+	const [isLoading, setIsLoading] = useState(false);
+	//const pageEndPoint = createRef(); //에러...
+	const pageEndPoint = useRef();
+	//페이지 증가 함수
+	const addPage = () => {
+		setPage((prevPage) => {
+			//console.log(prevPage);
+			return prevPage + 1;
+		});
+	};
+	//페이지 요청 함수
+	const requestPage = async (page) => {
+		await axios
+			.get(`${API_URL}/api/boards?page=${page}`, {
 				// headers: {
 				// 	// "ngrok-skip-browser-warning": "69420",
 				// 	Authorization: `Bearer ${accessToken}`,
 				// },
 			})
 			.then((res) => {
-				setStoryData(res.data.data);
+				setStoryData((prevData) => [...prevData, ...res.data.data]);
+				setIsLoading(true);
 			})
 			.catch((err) => {
 				console.log(err);
 			});
-	}, []);
+	};
+
+	//페이지 바뀔때마다 데이터 요청
+	useEffect(() => {
+		requestPage(page);
+	}, [page]);
+
+	//Intersection Observer로 로딩 여부 확인
+	useEffect(() => {
+		if (isLoading) {
+			//로딩시 페이지 추가
+			const observer = new IntersectionObserver(
+				(entries) => {
+					if (entries[0].isIntersecting) {
+						addPage();
+					}
+				},
+				{ threshold: 0.4 }
+			);
+			//옵저버 탐색
+			observer.observe(pageEndPoint.current);
+		}
+	}, [isLoading]);
+
+	//이전 버전
+	// useEffect(() => {
+	// 	axios
+	// 		.get(`${API_URL}/api/boards?page=1`, {
+	// 			// headers: {
+	// 			// 	// "ngrok-skip-browser-warning": "69420",
+	// 			// 	Authorization: `Bearer ${accessToken}`,
+	// 			// },
+	// 		})
+	// 		.then((res) => {
+	// 			setStoryData([...storyData, ...res.data.data]);
+	// 		})
+	// 		.catch((err) => {
+	// 			console.log(err);
+	// 		});
+	// }, []);
+
 	const handleWriteFBtnOnClick = () => {
 		navigate(`/storywrite`);
 	};
 	return (
-		<div>
+		<Wrap>
 			<TitleWrap>
 				<h3 className="active">모두의 스토리</h3>
 				<h3>친구의 스토리</h3>
 			</TitleWrap>
 			<SearchBar />
 			<StoryBoardWrap>
-				{storyData?.map((el) => {
-					return <StorySingle key={el.id} data={el} />;
+				{storyData?.map((el, idx) => {
+					return <StorySingle key={idx} data={el} />;
 				})}
 			</StoryBoardWrap>
 			<WriteFloatButton click={handleWriteFBtnOnClick} />
-		</div>
+			{/* {isLoading && <Loading ref={pageEndPoint} />} */}
+			{isLoading && (
+				<div className="loadingObserver" ref={pageEndPoint}>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+				</div>
+			)}
+		</Wrap>
 	);
 };
 export default Story;


### PR DESCRIPTION
## 작업개요
- 스토리 무한스크롤 구현. but 고도화 필요 (이슈번호 #182)
- 로딩 UI 수정(ref 사용하는 경우 대비)

## worklog
1. 무한스크롤 방법 고심하기, 서치
- 무한스크롤을 구현하는 방법에는 스크롤 이벤트, Intersection Observer를 사용하는 방법 이렇게 두가지가 있습니다.
이중에서 성능상의 이유로 Intersection Observer를 사용하는 방법이 좋다는 판단을 내렸고 이 방법으로 개발하게 되었습니다.
요 I.O.가 무엇인지는 원작자 MDN 슨생님들의 사이트에 잘 설명이 되어있습니다.
> https://developer.mozilla.org/ko/docs/Web/API/Intersection_Observer_API
2. 무한스크롤 의사코드
- 이번 기능은 제일 고심하고 무에서 시작하는 작업이기에 멘토 제리님의 말씀+여러 검색결과에 기반해 다음과 같이 의사코드를 작성해 보았습니다.  

```
1. 페이지가 바뀔 때마다 요청할 부분을 함수로 빼둔다
  -> page 부분은 매개변수로 받도록 한다.
  -> 응답받을 때 로딩 true로 바꿔주기
  -> 해보고 안되면 비동기 잘 확인하기
  2. page를 저장할 state를 만든다
  3. 로딩 여부를 저장할 state를 만든다
  4. 로딩UI를 불러와서, useRef로 연결한다
  5. page가 1씩 더해지는 함수를 만든다: 2의 setState 사용
  6. useEffect로 page가 바뀔 때마다 요청한다(1의 함수 사용)
  7. Intersection Observer를 통해 로딩 여부를 3의 state를 통해 확인하고, 5의 함수를 실행시킨다
  8. 7을 3의 로딩 여부가 변경될 때마다 호출되도록 useEffect를 사용한다
```

3. 부족한 부분 해결하기: 로딩 스켈레톤 사용
- 처음에 로딩 UI를 사용했는데, useRef 때문에 애를 먹었습니다. 이는 어려웠던 점에 상세하게 쓸게요
-  기존 로딩 UI가 스토리 컨텐츠들에 비해 height가 작아서 로딩 시점이 애매했습니다. (로딩 시점은 이 로딩 UI가 나타날 때 옵저버가 포착합니다.)
-  때문에 로딩 UI보다 로딩 스켈레톤을 사용하는게 UXUI 적으로 나아보였습니다. 그래서 급하게 CSS 애니메이션 동원하여 로딩 스켈레톤을 만들었습니다.
## trouble shooting & 어려웠던 점

1. useRef
- 무한스크롤은 로딩 UI가 화면에 나타나는 여부를 감지하여 동작하기 때문에 useRef가 필수입니다. 
- 그런데 useRef는 **리액트 컴포넌트, 일반 컴포넌트에만 사용이 가능합니다.** 
- 이것 때문에 스타일드 컴포넌트로 만든 로딩 UI에 useRef를 그냥 사용할 수 없었고, 여러 시행착오 끝에 커스텀 컴포넌트에는 forwardRef라는 것을 사용해야 한다는 것을 알아냈습니다.
- 커스텀 컴포넌트(스타일드 컴포넌트 포함)에 useRef를 사용하려면, 함수형 컴포넌트의 경우 다음과 같이 사용합니다.

```jsx
//컴포넌트 설정시
const Loading = forwardRef((props, ref) => {
	return (
		<Spinner ref={ref} />
	);
});
//컴포넌트 사용시
<Loading ref={loadingPoint}/>
```

여기서 주의할 것은 컴포넌트 생성시 **props라는 것을 사용하지 않아도 (props, ref) 이렇게 설정해줘야 합니다.**

2. 마지막 페이지 판별
- 무한스크롤시 계속 로딩할 수 없고, 마지막 페이지인 경우 로딩 스켈레톤이 없어야 합니다.
- 백엔드에서 마지막 페이지인지 알 수 있는지 방법을 물어보고 코드를 좀 더 고도화 하도록 하겠습니다.

3. 여기서 더 지체했다간 댓글 CRUD를 구현할 수 없으므로... 일단 댓글 CRUD를 진행하고 무한스크롤을 좀 더 고도화 하도록 하겠습니다..!