### PR TITLE
[feat/fe-storyComment] 댓글 CRUD 구현, API 연결 (좋아요 기능 제외)

### DIFF
--- a/client/src/components/StoryBtn.jsx
+++ b/client/src/components/StoryBtn.jsx
@@ -34,6 +34,12 @@ const StoryBtn = ({ size, type, clickHandler }) => {
 					<EditIcon />
 				</>
 			) : null}
+			{type === "editComplete" ? (
+				<>
+					수정완료
+					<EditIcon />
+				</>
+			) : null}
 			{type === "delete" ? (
 				<>
 					삭제

--- a/client/src/components/StoryComment.jsx
+++ b/client/src/components/StoryComment.jsx
@@ -1,12 +1,14 @@
 import styled from "styled-components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import HeartIcon from "./../assets/heart_sprite.svg";
 import SinglePofileWrap from "./SingleProfileWrap";
 import StoryBtn from "./StoryBtn";
+import displayedAt from "../util/displayedAt";
 
 const Wrap = styled.div`
 	display: flex;
 	align-items: center;
+	margin-bottom: 16px;
 
 	.comment_body {
 		flex: 1;
@@ -76,24 +78,62 @@ const CommentLike = styled.div`
 	}
 `;
 
-const StoryComment = () => {
-	const [isMe, setIsMe] = useState(true);
-	const [isEdit, setIsEdit] = useState(true);
+const StoryComment = ({ memberId, data, handleEdit, handleDelete }) => {
+	const [isMe, setIsMe] = useState(false);
+	const [isEdit, setIsEdit] = useState(false);
+	const [content, setContent] = useState("");
+
+	useEffect(() => {
+		if (data.memberId === memberId) setIsMe(true);
+	}, []);
+
+	const handleChangeEditClick = () => {
+		setIsEdit(true);
+	};
+
+	const handleEditContentChange = (e) => {
+		setContent(e.currentTarget.value);
+	};
+
 	return (
 		<Wrap className="card sm">
 			<div className="comment_body">
-				<SinglePofileWrap className="profile_wrap" imgSize="small" name="맑게고인뜨악어" subInfo="3분전" />
+				<SinglePofileWrap
+					className="profile_wrap"
+					imgSize="small"
+					imgSrc={data.profileImage}
+					name={data.nickname}
+					subInfo={displayedAt(data.createdAt)}
+				/>
 				{isEdit ? (
 					<div className="content_wrap edit">
-						<textarea placeholder="내용을 입력하세요" minLength="5"></textarea>
+						<textarea
+							placeholder="내용을 입력하세요"
+							minLength="5"
+							defaultValue={data.content}
+							onChange={(e) => handleEditContentChange(e)}
+						></textarea>
 					</div>
 				) : (
-					<div className="content_wrap">안녕하세요 저는 뜨악어에요 뜨거운 관심 캄사합니다</div>
+					<div className="content_wrap">{data.content}</div>
 				)}
 				{isMe ? (
 					<BtnWrap>
-						<StoryBtn type="edit" />
-						<StoryBtn type="delete" />
+						{isEdit ? (
+							<StoryBtn
+								type="editComplete"
+								clickHandler={() => {
+									handleEdit(data.id, content);
+									setIsEdit(false);
+								}}
+							/>
+						) : (
+							<StoryBtn type="edit" clickHandler={handleChangeEditClick} />
+						)}
+						<StoryBtn
+							type="delete"
+							clickHandler={() => handleDelete(data.id)}
+						/>
 					</BtnWrap>
 				) : null}
 			</div>

--- a/client/src/components/StoryComments.jsx
+++ b/client/src/components/StoryComments.jsx
@@ -1,0 +1,141 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+import StoryComment from "../components/StoryComment";
+import { API_URL } from "../data/apiUrl";
+import { useSelector } from "react-redux";
+
+const CommentWriteWrap = styled.div`
+	margin-bottom: 24px;
+	text-align: right;
+	.title {
+		width: 100%;
+		margin-bottom: 16px;
+		text-align: left;
+		font-size: var(--font-body1-size);
+		color: var(--strong-color);
+	}
+	textarea {
+		margin-bottom: 16px;
+	}
+	button.normal {
+		border-radius: var(--border-radius-sm);
+	}
+`;
+
+const StoryComments = ({ boardId }) => {
+	const loginInfo = useSelector((state) => state.islogin.login);
+	const accessToken = loginInfo.accessToken;
+	const memberId = loginInfo.memberId;
+	const [comment, setComment] = useState("");
+	const [commentsList, setCommentsList] = useState([]);
+	//댓글 입력
+	const handleCommentChange = (e) => {
+		setComment(e.currentTarget.value);
+	};
+
+	useEffect(() => {
+		getCommentsList();
+	}, [commentsList]);
+
+	//CRUD
+	//CREATE: 댓글 생성
+	const handleWriteClick = () => {
+		axios
+			.post(
+				`${API_URL}/api/boards/${boardId}/comments`,
+				{ content: comment },
+				{
+					headers: {
+						Authorization: `Bearer ${accessToken}`,
+					},
+				}
+			)
+			.then((res) => {
+				setCommentsList((prevData) => [res.data.data, ...prevData]);
+				setComment("");
+			})
+			.catch((err) => {
+				console.log(err);
+				alert("댓글 등록에 실패했습니다.");
+			});
+	};
+	//READ: 댓글 불러오기
+	const getCommentsList = () => {
+		axios
+			.get(`${API_URL}/api/boards/${boardId}/comments`, {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			})
+			.then((res) => {
+				setCommentsList(res.data.data);
+			})
+			.catch((err) => {
+				console.log(err);
+			});
+	};
+
+	//UPDATE: 댓글 수정
+	const handleEditClick = (commentsId, content) => {
+		axios
+			.patch(
+				`${API_URL}/api/boards/comments/${commentsId}`,
+				{ content },
+				{
+					headers: {
+						Authorization: `Bearer ${accessToken}`,
+					},
+				}
+			)
+			.then((res) => {})
+			.catch((err) => {
+				console.log(err);
+				alert("댓글 수정에 실패했습니다.");
+			});
+	};
+	//DELETE: 댓글 삭제
+	const handleDeleteClick = (commentsId) => {
+		axios
+			.delete(`${API_URL}/api/boards/comments/${commentsId}`, {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			})
+			.then((res) => {
+				alert("댓글을 삭제합니다.");
+			})
+			.catch((err) => {
+				alert("댓글 삭제에 실패했습니다.");
+			});
+	};
+	return (
+		<>
+			<CommentWriteWrap className="card sm">
+				<div className="title">댓글 작성</div>
+				<textarea
+					placeholder="댓글을 입력하세요"
+					onChange={(e) => {
+						handleCommentChange(e);
+					}}
+					value={comment}
+				></textarea>
+				<button className="normal" onClick={handleWriteClick}>
+					댓글 입력
+				</button>
+			</CommentWriteWrap>
+			{commentsList?.map((el) => {
+				return (
+					<StoryComment
+						key={el.id}
+						data={el}
+						memberId={memberId}
+						handleEdit={handleEditClick}
+						handleDelete={handleDeleteClick}
+					/>
+				);
+			})}
+		</>
+	);
+};
+export default StoryComments;

--- a/client/src/pages/StoryDetail.jsx
+++ b/client/src/pages/StoryDetail.jsx
@@ -8,7 +8,7 @@ import { API_URL } from "../data/apiUrl";
 import axios from "axios";
 import displayedAt from "../util/displayedAt";
 import SinglePofileWrap from "../components/SingleProfileWrap";
-import StoryComment from "../components/StoryComment";
+import StoryComments from "../components/StoryComments";
 import StoryBtn from "../components/StoryBtn";
 import StoryFileView from "./../components/StoryFileView";
 
@@ -108,24 +108,6 @@ const CommentsCountTag = styled.div`
 	}
 `;
 
-const CommentWriteWrap = styled.div`
-	margin-bottom: 24px;
-	text-align: right;
-	.title {
-		width: 100%;
-		margin-bottom: 16px;
-		text-align: left;
-		font-size: var(--font-body1-size);
-		color: var(--strong-color);
-	}
-	textarea {
-		margin-bottom: 16px;
-	}
-	button.normal {
-		border-radius: var(--border-radius-sm);
-	}
-`;
-
 const StoryDetail = () => {
 	const navigate = useNavigate();
 	let params = useParams();
@@ -134,6 +116,7 @@ const StoryDetail = () => {
 	const memberId = loginInfo.memberId;
 	const [isMe, setIsMe] = useState(false);
 	const [storyData, setStoryData] = useState({});
+	const [commentsList, setCommentsList] = useState([]);
 	//const [isBoardLike, setIsBoardLike] = useState(storyData.likeStatus);
 	useEffect(() => {
 		axios
@@ -150,7 +133,7 @@ const StoryDetail = () => {
 			.catch((err) => {
 				console.log(err);
 			});
-	});
+	}, []);
 	let type = "";
 	if (storyData.contentType) type = storyData.contentType.split("/")[0];
 
@@ -258,12 +241,7 @@ const StoryDetail = () => {
 				) : null}
 			</div>
 			<Title>댓글</Title>
-			<CommentWriteWrap className="card sm">
-				<div className="title">댓글 작성</div>
-				<textarea placeholder="댓글을 입력하세요"></textarea>
-				<button className="normal">댓글 입력</button>
-			</CommentWriteWrap>
-			<StoryComment />
+			<StoryComments boardId={params.boardid} />
 		</>
 	);
 };


### PR DESCRIPTION
## 작업개요
- 댓글 CRUD 구현, API 연결 (이슈번호 #187)
- But 댓글 좋아요 기능은 제외

## worklog
1. 코드가 길어질 것을 대비해 댓글 부분을 컴포넌트로 분리
2. 핸들러 함수 작성: 각 CRUD에 맞는 api 요청을 작성했습니다.
3. C -> R -> U -> D 순서로 버튼에 각 핸들러를 하나씩 연결하고 테스트 했습니다.
4. 기존 수정, 삭제 -> 수정, 수정완료, 삭제로 버튼 케이스 추가
- 수정 버튼을 누르면 댓글 수정으로 바뀌어야 하고, 수정 완료 버튼을 누르면 댓글 수정이 완료되어야 하므로 해당 부분 추가했습니다.
5. 댓글 수정, 삭제는 나 자신인 경우만 되어야 하므로 판별하는 코드를 추가했습니다.

## trouble shooting & 어려웠던 점
1. setState 사용시 주의
컴포넌트로 분리하며 작업하다보니, 모르고 한 컴포넌트에

```
 if(~) setState()
```

이렇게 작성했습니다. 이러면 Too many rederings 오류 나니까 저처럼 저렇게 바로 setState 작성하지 마세요! ㅎㅎ 시간 허비함요...
2. CRUD를 한 번에 구현하다보니 쉽지 않았습니다. 하지만 한 번에 구현하는 만큼 각 차이를 알 수 있어서 좋았어요! 