### PR TITLE
[feat/fe-userRedux] Refactor user state with redux toolkit

### DIFF
--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,12 +1,12 @@
-import styled from "styled-components";
-import { ReactComponent as ProfileImg } from "./../assets/defaultImg.svg";
-import { NavLink, useNavigate } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
-import { useState, useEffect } from "react";
-import axios from "axios";
-import { API_URL } from "../data/apiUrl";
-import { logout } from "../redux/slice/loginstate";
-import { userInfo } from "../redux/slice/userInfo";
+import styled from 'styled-components';
+import { ReactComponent as ProfileImg } from './../assets/defaultImg.svg';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { API_URL } from '../data/apiUrl';
+import { logout } from '../redux/slice/loginstate';
+import { userInfo } from '../redux/slice/userInfo';
 const HeaderWrap = styled.header`
   position: absolute;
   left: 0;
@@ -76,18 +76,19 @@ const BtnWrap = styled.div`
 
 const Header = () => {
   const loginInfo = useSelector((state) => state.islogin.login);
-  const [user, setUser] = useState({});
+  const userInform = useSelector((state) => state.userInfo.userInfo);
+  const [nickname, setNickname] = useState(null);
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
   useEffect(() => {
     if (loginInfo?.isLogin) {
       axios.get(`${API_URL}/api/members/${loginInfo?.memberId}`).then((res) => {
-        setUser(res.data.data);
+        setNickname(res.data.data.nickname);
         dispatch(userInfo(res.data.data));
       });
     }
-  }, [loginInfo?.isLogin, loginInfo?.memberId]);
+  }, [loginInfo?.isLogin, loginInfo?.memberId, dispatch]);
 
   const handleLogout = () => {
     axios
@@ -103,21 +104,21 @@ const Header = () => {
       .then(() => {
         localStorage.clear();
         dispatch(logout({ accessToken: null, memberId: null, isLogin: false }));
-        navigate("/");
+        navigate('/');
       });
   };
 
   return (
     <HeaderWrap>
-      {user && loginInfo?.isLogin ? (
+      {userInform && loginInfo?.isLogin ? (
         <>
           <ProfileWrap>
             <a href={`/profile/`}>
               <span className="alert">알림</span>
-              <span className="user_nickname">{user.nickname}</span>
+              <span className="user_nickname">{nickname}</span>
               <div className="user_img">
-                {user.profileImage ? (
-                  <img src={user.profileImage} alt="프로필이미지" />
+                {userInform.profileImage ? (
+                  <img src={userInform.profileImage} alt="프로필이미지" />
                 ) : (
                   <ProfileImg />
                 )}
@@ -132,13 +133,13 @@ const Header = () => {
         <BtnWrap>
           <NavLink
             to="/signup"
-            className={({ isActive }) => (isActive ? "active" : "")}
+            className={({ isActive }) => (isActive ? 'active' : '')}
           >
             회원가입
           </NavLink>
           <NavLink
             to="/login"
-            className={({ isActive }) => (isActive ? "active" : "")}
+            className={({ isActive }) => (isActive ? 'active' : '')}
           >
             로그인
           </NavLink>

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -1,5 +1,5 @@
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import styled from 'styled-components';
 import SinglePofileWrap from './SingleProfileWrap';
 import { ReactComponent as Setting } from '../assets/settingsIcon.svg';
@@ -8,6 +8,7 @@ import { ReactComponent as EmptyHeart } from '../assets/heartEmptyIcon.svg';
 import axios from 'axios';
 import { API_URL } from '../data/apiUrl';
 import { useState, useEffect } from 'react';
+import { setProfile } from '../redux/slice/profileSlice';
 
 const ProfileWrap = styled.div`
   width: var(--col-4);
@@ -91,44 +92,104 @@ const ProfileCard = () => {
   const [isMe, setIsMe] = useState(false);
   const { userid } = useParams();
   const loginInfo = useSelector((state) => state.islogin.login);
+  const userInfo = useSelector((state) => state.profile.user);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
 
   const handleFollow = () => {
     if (loginInfo?.isLogin) {
-      axios.post(
-        `${API_URL}/api/members/${userid}/follows`,
-        {},
-        {
-          headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-        }
-      );
-      window.location.reload();
+      axios
+        .post(
+          `${API_URL}/api/members/${userid}/follows`,
+          {},
+          {
+            headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+          }
+        )
+        .then((res) => {
+          if (res.data === '팔로우가 완료되었습니다.') {
+            dispatch(
+              setProfile({
+                ...userInfo,
+                followStatus: !userInfo.followStatus,
+                followerCount: userInfo.followerCount + 1,
+              })
+            );
+          } else {
+            dispatch(
+              setProfile({
+                ...userInfo,
+                followStatus: !userInfo.followStatus,
+                followerCount: userInfo.followerCount - 1,
+              })
+            );
+          }
+        });
     } else return navigate(`/login`);
   };
 
   const handleLike = () => {
     if (loginInfo?.isLogin) {
-      axios.post(
-        `${API_URL}/api/members/${userid}/likes`,
-        {},
-        {
-          headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-        }
-      );
-      window.location.reload();
+      axios
+        .post(
+          `${API_URL}/api/members/${userid}/likes`,
+          {},
+          {
+            headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+          }
+        )
+        .then((res) => {
+          if (res.data === '좋아요가 완료되었습니다.') {
+            dispatch(
+              setProfile({
+                ...userInfo,
+                likeStatus: !userInfo.likeStatus,
+                likeCount: userInfo.likeCount + 1,
+              })
+            );
+          } else {
+            dispatch(
+              setProfile({
+                ...userInfo,
+                likeStatus: !userInfo.likeStatus,
+                likeCount: userInfo.likeCount - 1,
+              })
+            );
+          }
+        });
     } else return navigate(`/login`);
   };
 
   const handleBlock = () => {
     if (loginInfo?.isLogin) {
-      axios.post(
-        `${API_URL}/api/members/${userid}/blocks`,
-        {},
-        {
-          headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-        }
-      );
-      window.location.reload();
+      axios
+        .post(
+          `${API_URL}/api/members/${userid}/blocks`,
+          {},
+          {
+            headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+          }
+        )
+        .then((res) => {
+          if (
+            res.data ===
+            '해당 유저를 차단하셨습니다. 팔로우와 좋아요가 취소됩니다.'
+          ) {
+            dispatch(
+              setProfile({
+                ...userInfo,
+                blockStatus: !userInfo.blockStatus,
+              })
+            );
+          } else {
+            dispatch(
+              setProfile({
+                ...userInfo,
+                blockStatus: !userInfo.blockStatus,
+              })
+            );
+          }
+        });
     } else return navigate(`/login`);
   };
 
@@ -139,9 +200,10 @@ const ProfileCard = () => {
       })
       .then((res) => {
         setUser(res.data.data);
+        dispatch(setProfile(res.data.data));
       });
     Number(userid) === loginInfo?.memberId ? setIsMe(true) : setIsMe(false);
-  }, [userid, loginInfo?.accessToken, loginInfo?.memberId]);
+  }, [userid, loginInfo?.accessToken, loginInfo?.memberId, dispatch]);
 
   if (user) {
     return (
@@ -164,9 +226,9 @@ const ProfileCard = () => {
               </div>
             ) : (
               <div className="icon">
-                {user.blockStatus ? null : (
+                {userInfo.blockStatus ? null : (
                   <>
-                    {user.likeStatus ? (
+                    {userInfo.likeStatus ? (
                       <Heart className="likes" onClick={handleLike} />
                     ) : (
                       <EmptyHeart className="likes" onClick={handleLike} />
@@ -179,22 +241,22 @@ const ProfileCard = () => {
           <FollowWrap>
             <Follow>
               <div className="follow">팔로잉</div>
-              <div className="number">{user.followingCount}</div>
+              <div className="number">{userInfo.followingCount}</div>
             </Follow>
             <Follow>
               <div className="follow">팔로워</div>
-              <div className="number">{user.followerCount}</div>
+              <div className="number">{userInfo.followerCount}</div>
             </Follow>
             <Follow>
               <div className="follow">좋아요</div>
-              <div className="number">{user.likeCount}</div>
+              <div className="number">{userInfo.likeCount}</div>
             </Follow>
           </FollowWrap>
           {!isMe ? (
             <ButtonWrap>
-              {user.blockStatus ? null : (
+              {userInfo.blockStatus ? null : (
                 <>
-                  {user.followStatus ? (
+                  {userInfo.followStatus ? (
                     <button className="em" onClick={handleFollow}>
                       팔로우 해제하기
                     </button>
@@ -211,7 +273,7 @@ const ProfileCard = () => {
             </ButtonWrap>
           ) : null}
         </ProfileWrap>
-        {user.blockStatus ? null : (
+        {userInfo.blockStatus ? null : (
           <>
             <ProfileWrap className="card sm">
               <div className="inform_title">주로하는 게임</div>

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -21,6 +21,7 @@ const ProfileWrap = styled.div`
     margin-top: 6px;
     font-size: var(--font-body2-size);
     color: var(--white);
+    white-space: pre-wrap;
   }
 `;
 

--- a/client/src/components/ProfileContent.jsx
+++ b/client/src/components/ProfileContent.jsx
@@ -40,9 +40,7 @@ const TabWrap = styled.div`
 `;
 
 const ProfileContent = () => {
-  const loginInfo = useSelector((state) => state.islogin.login);
-  const { userid } = useParams();
-  const [user, setUser] = useState(null);
+  const userInfo = useSelector((state) => state.profile.user);
   const [isMatch, setIsMatch] = useState(true);
   const [isStory, setIsStory] = useState(false);
 
@@ -51,20 +49,10 @@ const ProfileContent = () => {
     setIsStory((prev) => !prev);
   };
 
-  useEffect(() => {
-    axios
-      .get(`${API_URL}/api/members/${userid}`, {
-        headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-      })
-      .then((res) => {
-        setUser(res.data.data);
-      });
-  }, [userid, loginInfo?.accessToken]);
-
-  if (user) {
+  if (userInfo) {
     return (
       <ContentWrap className="card">
-        {user.blockStatus ? (
+        {userInfo.blockStatus ? (
           <div className="block_container">
             <BlockUser />
             <div className="block_msg">차단한 유저의 프로필입니다.</div>

--- a/client/src/redux/slice/blockSlice.js
+++ b/client/src/redux/slice/blockSlice.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const blockSlice = createSlice({
+  name: 'blockSlice',
+  initialState: { blockUsers: [] },
+  reducers: {
+    setBlock: (state, action) => {
+      state.blockUsers = action.payload;
+    },
+  },
+});
+
+export default blockSlice;
+export const { setBlock } = blockSlice.actions;

--- a/client/src/redux/slice/profileSlice.js
+++ b/client/src/redux/slice/profileSlice.js
@@ -1,0 +1,14 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const profileSlice = createSlice({
+  name: 'profileSlice',
+  initialState: { user: {} },
+  reducers: {
+    setProfile: (state, action) => {
+      state.user = action.payload;
+    },
+  },
+});
+
+export default profileSlice;
+export const { setProfile } = profileSlice.actions;

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -1,17 +1,22 @@
-import Logined from "./slice/loginstate";
-import { configureStore } from "@reduxjs/toolkit";
-import { persistReducer } from "redux-persist";
-import storage from "redux-persist/lib/storage";
-import { combineReducers } from "@reduxjs/toolkit";
-import GameInfo from "./slice/matchInfo";
-import UserInfo from "./slice/userInfo";
+import Logined from './slice/loginstate';
+import { configureStore } from '@reduxjs/toolkit';
+import { persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import { combineReducers } from '@reduxjs/toolkit';
+import GameInfo from './slice/matchInfo';
+import UserInfo from './slice/userInfo';
+import blockSlice from './slice/blockSlice';
+import profileSlice from './slice/profileSlice';
+
 const reducer = combineReducers({
   islogin: Logined.reducer,
   games: GameInfo.reducer,
   userInfo: UserInfo.reducer,
+  block: blockSlice.reducer,
+  profile: profileSlice.reducer,
 });
 const persistConfig = {
-  key: "persist",
+  key: 'persist',
   storage,
 };
 const combineReducer = persistReducer(persistConfig, reducer);
@@ -22,5 +27,4 @@ const store = configureStore({
       serializableCheck: false,
     }),
 });
-
 export default store;


### PR DESCRIPTION
## 작업개요
- 강제적인 새로고침 없이 상태가 업데이트 되도록 코드 수정

## worklog
- 강제로 새로고침 하지 않고(`window.location.reload`) 보여지는 화면이 바뀌도록 redux toolkit을 이용한 코드로 리팩토링 했습니다.
> ### 기존에 새로고침해서 헤더를 업데이트 하던 방식
> ![하아](https://user-images.githubusercontent.com/111413253/213735085-f6277d1c-1ae3-4672-af02-1c1a63d97e39.gif)
> ### 이제는 새로고침 없이 헤더를 업데이트
> ![휴우](https://user-images.githubusercontent.com/111413253/214109471-f86505b2-7d94-4194-bde7-e310d8181a69.gif)

> ### 기존에 새로고침해서 팔로우 상태를 업데이트 하던 방식
> ![냥](https://user-images.githubusercontent.com/111413253/213880661-934c6403-525f-45ac-a2f3-a9b3dca52d14.gif)
> ### 이제는 새로고침 없이 팔로우 상태를 업데이트
> ![뇽](https://user-images.githubusercontent.com/111413253/214109770-930c9431-c1f8-4916-b639-739104b6839a.gif)

> ### 기존에 새로고침해서 좋아요 상태를 업데이트 하던 방식
> ![냐냥](https://user-images.githubusercontent.com/111413253/213880682-d6fe00c8-bf01-4d18-88bb-9e55af9742e6.gif)
> ### 이제는 새로고침 없이 좋아요 상태를 업데이트
> ![뇨뇽](https://user-images.githubusercontent.com/111413253/214110328-90b579c2-9c22-48eb-96f4-b3501d9660e4.gif)

> ### 기존에 새로고침해서 차단 상태를 업데이트 하던 방식
> ![뉴늉](https://user-images.githubusercontent.com/111413253/213880719-027f8515-b234-4296-9213-9b976ef2eddd.png)
> 지금 보니까 위 사진은... 움짤이 아니었네요.. 화면이 깜빡이면서 차단 화면을 띄워줬었습니다!
> ### 이제는 새로고침 없이 차단 상태를 업데이트
> ![녀녕](https://user-images.githubusercontent.com/111413253/214110666-cd45f7ce-f4fa-4c60-bb5f-eafefd1de882.gif)

이제 새로고침 때문에 화면이 반짝! 하고 깜빡이는 일이 없습니다!

## trouble shooting & 어려웠던 점
- 사용한 방법이 redux store에 상태값을 저장해서 이를 강제로 조작하여 변경된 값을 화면에 띄우는 방식을 사용했기 때문에 같은 store state를 사용하는 컴포넌트에서 예기치 않은 문제들이 발생했습니다. 예를 들면 Profile Edit 페이지에서 입력한 값이 **서버에는 저장된 것이 아닌데** `dispatch`로 state의 수정 값을 전달했기 때문에 다른 컴포넌트에서 `useSelector`로 받아온 값이 그대로 뜬다던가.. (실제로는 수정된게 아님에도 불구하고)
이런 경우를 많이 따져야 해서 너무 복잡하고 ㅋㅋㅋㅋㅋㅋ 의도하지 않은 `useState`를 새로 만들어야 하는 일도 있었습니다🥹 내 정보와 관련된 곳에는 전부 store에 저장된 state를 사용하려 했는데 어쩔 수 없이 get 요청을 받아서 써야하는 일도 있었고… 생각만큼 원하는 대로 API 요청을 조절하기가 쉽지 않았습니다,, (그냥 제가 바보라서 방법을 모르는 것 같아요)
