### PR TITLE
[feat/fe-profilePageRefactor] Refactor Profile pagination

### DIFF
--- a/client/src/components/BlockUserList.jsx
+++ b/client/src/components/BlockUserList.jsx
@@ -23,6 +23,10 @@ const ListWrap = styled.div`
         color: var(--strong-color);
       }
     }
+    .content_none {
+      width: 100%;
+      text-align: center;
+    }
   }
 `;
 
@@ -73,22 +77,28 @@ const BlockUserList = () => {
       <>
         <ListWrap>
           <ul>
-            {blockUser.map((block) => (
-              <li key={block.id}>
-                <SingleProfileWrap
-                  className="profile_container"
-                  imgSrc={block.profileImage}
-                  name={block.nickname}
-                  subInfo={block.identifier}
-                />
-                <button
-                  className="unblock_btn"
-                  onClick={() => handleBlock(block.id)}
-                >
-                  차단해제
-                </button>
+            {blockUser.length > 0 ? (
+              blockUser.map((block) => (
+                <li key={block.id}>
+                  <SingleProfileWrap
+                    className="profile_container"
+                    imgSrc={block.profileImage}
+                    name={block.nickname}
+                    subInfo={block.identifier}
+                  />
+                  <button
+                    className="unblock_btn"
+                    onClick={() => handleBlock(block.id)}
+                  >
+                    차단해제
+                  </button>
+                </li>
+              ))
+            ) : (
+              <li>
+                <div className="content_none">차단한 유저가 없습니다.</div>
               </li>
-            ))}
+            )}
           </ul>
         </ListWrap>
         <ButtonWrap>

--- a/client/src/components/ProfileContent.jsx
+++ b/client/src/components/ProfileContent.jsx
@@ -2,11 +2,7 @@ import styled from 'styled-components';
 import { ReactComponent as BlockUser } from '../assets/blockUser.svg';
 import ProfileContentList from './ProfileContentList';
 import { useState } from 'react';
-import { useEffect } from 'react';
-import axios from 'axios';
-import { useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { API_URL } from '../data/apiUrl';
 
 const ContentWrap = styled.div`
   width: var(--col-8);

--- a/client/src/components/ProfileContentList.jsx
+++ b/client/src/components/ProfileContentList.jsx
@@ -98,8 +98,11 @@ const ProfileContentList = ({ isMatch, isStory }) => {
       .then((res) => {
         setMatch(res.data.data);
         setMatchPageInfo(res.data.pageInfo);
+      })
+      .then(() => {
+        if (matchPage > matchPageInfo?.totalPages) setMatchPage(1);
       });
-  }, [matchPage, userid]);
+  }, [matchPage, userid, matchPageInfo?.totalPages]);
 
   useEffect(() => {
     axios
@@ -107,8 +110,11 @@ const ProfileContentList = ({ isMatch, isStory }) => {
       .then((res) => {
         setStory(res.data.data);
         setStoryPageInfo(res.data.pageInfo);
+      })
+      .then(() => {
+        if (storyPage > storyPageInfo?.totalPages) setStoryPage(1);
       });
-  }, [storyPage, userid]);
+  }, [storyPage, userid, storyPageInfo?.totalPages]);
 
   if (match && story) {
     return (

--- a/client/src/components/ProfilePagination.jsx
+++ b/client/src/components/ProfilePagination.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { useState } from 'react';
 import styled from 'styled-components';
 import { ReactComponent as ArrowBack } from '../assets/arrowBack.svg';
@@ -17,8 +18,10 @@ const PageWrap = styled.div`
     height: 32px;
     font-size: var(--font-body2-size);
   }
-  .active {
-    color: var(--yellow);
+  button {
+    &[aria-current='active'] {
+      color: var(--yellow);
+    }
   }
 `;
 
@@ -32,132 +35,58 @@ const ProfilePagination = ({
   storyPageInfo,
 }) => {
   const [matchFirstPage, setMatchFirstPage] = useState(matchPage);
+  const [matchPageCount, setMatchPageCount] = useState(5);
   const matchTotalPage = matchPageInfo.totalPages;
-  const matchFirstNum = matchFirstPage - (matchFirstPage % 8) + 1;
+  const matchFirstNum = matchFirstPage - (matchFirstPage % 5) + 1;
+  const matchLastNum = matchFirstPage - (matchFirstPage % 5) + 5;
 
   const [storyFirstPage, setStoryFirstPage] = useState(storyPage);
+  const [storyPageCount, setStoryPageCount] = useState(5);
   const storyTotalPage = storyPageInfo.totalPages;
-  const storyFirstNum = storyFirstPage - (storyFirstPage % 8) + 1;
+  const storyFirstNum = storyFirstPage - (storyFirstPage % 5) + 1;
+  const storyLastNum = storyFirstPage - (storyFirstPage % 5) + 5;
 
-  const [isMatchPage1, setIsMatchPage1] = useState(true);
-  const [isMatchPage2, setIsMatchPage2] = useState(false);
-  const [isMatchPage3, setIsMatchPage3] = useState(false);
-  const [isMatchPage4, setIsMatchPage4] = useState(false);
-  const [isMatchPage5, setIsMatchPage5] = useState(false);
-
-  const [isStoryPage1, setIsStoryPage1] = useState(true);
-  const [isStoryPage2, setIsStoryPage2] = useState(false);
-  const [isStoryPage3, setIsStoryPage3] = useState(false);
-  const [isStoryPage4, setIsStoryPage4] = useState(false);
-  const [isStoryPage5, setIsStoryPage5] = useState(false);
+  useEffect(() => {
+    if (matchLastNum > matchTotalPage) setMatchPageCount(matchTotalPage % 5);
+    if (storyLastNum > storyTotalPage) setStoryPageCount(storyTotalPage % 5);
+  }, [matchLastNum, matchTotalPage, storyLastNum, storyTotalPage]);
 
   return (
     <PageWrap>
       {isMatch ? (
         <>
-          {matchTotalPage > 5 ? (
+          {matchTotalPage > 1 ? (
             <button
               className="page_content"
               onClick={() => {
                 setMatchPage(matchPage - 1);
                 setMatchFirstPage(matchPage - 2);
-                setIsMatchPage1(true);
-                setIsMatchPage2(false);
-                setIsMatchPage3(false);
-                setIsMatchPage4(false);
-                setIsMatchPage5(false);
               }}
+              disabled={matchPage === 1}
             >
               <ArrowBack />
             </button>
           ) : null}
-          {matchTotalPage >= matchFirstNum ? (
-            <button
-              className={'page_content' + (isMatchPage1 ? ' active' : '')}
-              onClick={() => {
-                setMatchPage(matchFirstNum);
-                setIsMatchPage1(true);
-                setIsMatchPage2(false);
-                setIsMatchPage3(false);
-                setIsMatchPage4(false);
-                setIsMatchPage5(false);
-              }}
-            >
-              {matchFirstNum}
-            </button>
-          ) : null}
-          {matchTotalPage >= matchFirstNum + 1 ? (
-            <button
-              className={'page_content' + (isMatchPage2 ? ' active' : '')}
-              onClick={() => {
-                setMatchPage(matchFirstNum + 1);
-                setIsMatchPage1(false);
-                setIsMatchPage2(true);
-                setIsMatchPage3(false);
-                setIsMatchPage4(false);
-                setIsMatchPage5(false);
-              }}
-            >
-              {matchFirstNum + 1}
-            </button>
-          ) : null}
-          {matchTotalPage >= matchFirstNum + 2 ? (
-            <button
-              className={'page_content' + (isMatchPage3 ? ' active' : '')}
-              onClick={() => {
-                setMatchPage(matchFirstNum + 2);
-                setIsMatchPage1(false);
-                setIsMatchPage2(false);
-                setIsMatchPage3(true);
-                setIsMatchPage4(false);
-                setIsMatchPage5(false);
-              }}
-            >
-              {matchFirstNum + 2}
-            </button>
-          ) : null}
-          {matchTotalPage >= matchFirstNum + 3 ? (
-            <button
-              className={'page_content' + (isMatchPage4 ? ' active' : '')}
-              onClick={() => {
-                setMatchPage(matchFirstNum + 3);
-                setIsMatchPage1(false);
-                setIsMatchPage2(false);
-                setIsMatchPage3(false);
-                setIsMatchPage4(true);
-                setIsMatchPage5(false);
-              }}
-            >
-              {matchFirstNum + 3}
-            </button>
-          ) : null}
-          {matchTotalPage >= matchFirstNum + 4 ? (
-            <button
-              className={'page_content' + (isMatchPage5 ? ' active' : '')}
-              onClick={() => {
-                setMatchPage(matchFirstNum + 4);
-                setIsMatchPage1(false);
-                setIsMatchPage2(false);
-                setIsMatchPage3(false);
-                setIsMatchPage4(false);
-                setIsMatchPage5(true);
-              }}
-            >
-              {matchFirstNum + 4}
-            </button>
-          ) : null}
-          {matchTotalPage > 5 ? (
+          {Array(matchPageCount)
+            .fill()
+            .map((_, idx) => (
+              <button
+                className="page_content"
+                key={idx + 1}
+                onClick={() => setMatchPage(matchFirstNum + idx)}
+                aria-current={matchPage === matchFirstNum + idx && 'active'}
+              >
+                {matchFirstNum + idx}
+              </button>
+            ))}
+          {matchTotalPage > 1 ? (
             <button
               className="page_content"
               onClick={() => {
                 setMatchPage(matchPage + 1);
                 setMatchFirstPage(matchPage);
-                setIsMatchPage1(true);
-                setIsMatchPage2(false);
-                setIsMatchPage3(false);
-                setIsMatchPage4(false);
-                setIsMatchPage5(false);
               }}
+              disabled={matchPage === matchTotalPage}
             >
               <ArrowForward />
             </button>
@@ -165,109 +94,38 @@ const ProfilePagination = ({
         </>
       ) : (
         <>
-          {storyTotalPage > 5 ? (
+          {storyTotalPage > 1 ? (
             <button
               className="page_content"
               onClick={() => {
                 setStoryPage(storyPage - 1);
                 setStoryFirstPage(storyPage - 2);
-                setIsStoryPage1(true);
-                setIsStoryPage2(false);
-                setIsStoryPage3(false);
-                setIsStoryPage4(false);
-                setIsStoryPage5(false);
               }}
+              disabled={storyPage === 1}
             >
               <ArrowBack />
             </button>
           ) : null}
-          {storyTotalPage >= storyFirstNum ? (
-            <button
-              className={'page_content' + (isStoryPage1 ? ' active' : '')}
-              onClick={() => {
-                setStoryPage(storyFirstNum);
-                setIsStoryPage1(true);
-                setIsStoryPage2(false);
-                setIsStoryPage3(false);
-                setIsStoryPage4(false);
-                setIsStoryPage5(false);
-              }}
-            >
-              {storyFirstNum}
-            </button>
-          ) : null}
-          {storyTotalPage >= storyFirstNum + 1 ? (
-            <button
-              className={'page_content' + (isStoryPage2 ? ' active' : '')}
-              onClick={() => {
-                setStoryPage(storyFirstNum + 1);
-                setIsStoryPage1(false);
-                setIsStoryPage2(true);
-                setIsStoryPage3(false);
-                setIsStoryPage4(false);
-                setIsStoryPage5(false);
-              }}
-            >
-              {storyFirstNum + 1}
-            </button>
-          ) : null}
-          {storyTotalPage >= storyFirstNum + 2 ? (
-            <button
-              className={'page_content' + (isStoryPage3 ? ' active' : '')}
-              onClick={() => {
-                setStoryPage(storyFirstNum + 2);
-                setIsStoryPage1(false);
-                setIsStoryPage2(false);
-                setIsStoryPage3(true);
-                setIsStoryPage4(false);
-                setIsStoryPage5(false);
-              }}
-            >
-              {storyFirstNum + 2}
-            </button>
-          ) : null}
-          {storyTotalPage >= storyFirstNum + 3 ? (
-            <button
-              className={'page_content' + (isStoryPage4 ? ' active' : '')}
-              onClick={() => {
-                setStoryPage(storyFirstNum + 3);
-                setIsStoryPage1(false);
-                setIsStoryPage2(false);
-                setIsStoryPage3(false);
-                setIsStoryPage4(true);
-                setIsStoryPage5(false);
-              }}
-            >
-              {storyFirstNum + 3}
-            </button>
-          ) : null}
-          {storyTotalPage >= storyFirstNum + 4 ? (
-            <button
-              className={'page_content' + (isStoryPage5 ? ' active' : '')}
-              onClick={() => {
-                setStoryPage(storyFirstNum + 4);
-                setIsStoryPage1(false);
-                setIsStoryPage2(false);
-                setIsStoryPage3(false);
-                setIsStoryPage4(false);
-                setIsStoryPage5(true);
-              }}
-            >
-              {storyFirstNum + 4}
-            </button>
-          ) : null}
-          {storyTotalPage > 5 ? (
+          {Array(storyPageCount)
+            .fill()
+            .map((_, idx) => (
+              <button
+                className="page_content"
+                key={idx + 1}
+                onClick={() => setStoryPage(storyFirstNum + idx)}
+                aria-current={storyPage === storyFirstNum + idx && 'active'}
+              >
+                {storyFirstNum + idx}
+              </button>
+            ))}
+          {storyTotalPage > 1 ? (
             <button
               className="page_content"
               onClick={() => {
                 setStoryPage(storyPage + 1);
                 setStoryFirstPage(storyPage);
-                setIsStoryPage1(true);
-                setIsStoryPage2(false);
-                setIsStoryPage3(false);
-                setIsStoryPage4(false);
-                setIsStoryPage5(false);
               }}
+              disabled={storyPage === storyTotalPage}
             >
               <ArrowForward />
             </button>

--- a/client/src/components/ProfilePagination.jsx
+++ b/client/src/components/ProfilePagination.jsx
@@ -54,9 +54,19 @@ const ProfilePagination = ({
     if (storyLastNum > storyTotalPage) {
       setStoryPageCount(storyTotalPage % 5);
     } else setStoryPageCount(5);
-  }, [matchLastNum, matchTotalPage, storyLastNum, storyTotalPage]);
 
-  console.log(matchPage);
+    if (matchFirstPage > matchPage) setMatchFirstPage(matchPage);
+    if (storyFirstPage > storyPage) setStoryFirstPage(storyPage);
+  }, [
+    matchLastNum,
+    matchTotalPage,
+    storyLastNum,
+    storyTotalPage,
+    matchPage,
+    matchFirstPage,
+    storyPage,
+    storyFirstPage,
+  ]);
 
   return (
     <PageWrap>

--- a/client/src/components/ProfilePagination.jsx
+++ b/client/src/components/ProfilePagination.jsx
@@ -47,9 +47,16 @@ const ProfilePagination = ({
   const storyLastNum = storyFirstPage - (storyFirstPage % 5) + 5;
 
   useEffect(() => {
-    if (matchLastNum > matchTotalPage) setMatchPageCount(matchTotalPage % 5);
-    if (storyLastNum > storyTotalPage) setStoryPageCount(storyTotalPage % 5);
+    if (matchLastNum > matchTotalPage) {
+      setMatchPageCount(matchTotalPage % 5);
+    } else setMatchPageCount(5);
+
+    if (storyLastNum > storyTotalPage) {
+      setStoryPageCount(storyTotalPage % 5);
+    } else setStoryPageCount(5);
   }, [matchLastNum, matchTotalPage, storyLastNum, storyTotalPage]);
+
+  console.log(matchPage);
 
   return (
     <PageWrap>

--- a/client/src/components/QuitCard.jsx
+++ b/client/src/components/QuitCard.jsx
@@ -4,7 +4,8 @@ import axios from 'axios';
 import { API_URL } from '../data/apiUrl';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { quit } from '../redux/slice/loginstate';
 
 const QuitWrap = styled.div`
   display: flex;
@@ -72,6 +73,7 @@ const ButtonWrap = styled.div`
 
 const QuitCard = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const loginInfo = useSelector((state) => state.islogin.login);
   const [user, setUser] = useState(null);
 
@@ -80,7 +82,11 @@ const QuitCard = () => {
       .delete(`${API_URL}/api/members/${loginInfo?.memberId}`, {
         headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
       })
-      .then(() => localStorage.clear());
+      .then(() => {
+        localStorage.clear();
+        dispatch(quit({ accessToken: null, memberId: null, isLogin: false }));
+        navigate('/');
+      });
   };
 
   useEffect(() => {

--- a/client/src/components/QuitCard.jsx
+++ b/client/src/components/QuitCard.jsx
@@ -76,9 +76,11 @@ const QuitCard = () => {
   const [user, setUser] = useState(null);
 
   const handleQuit = () => {
-    axios.delete(`${API_URL}/api/members/${loginInfo?.memberId}`, {
-      headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-    });
+    axios
+      .delete(`${API_URL}/api/members/${loginInfo?.memberId}`, {
+        headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+      })
+      .then(() => localStorage.clear());
   };
 
   useEffect(() => {

--- a/client/src/redux/slice/loginstate.js
+++ b/client/src/redux/slice/loginstate.js
@@ -18,7 +18,10 @@ const Logined = createSlice({
     logout: (state, action) => {
       state.login = action.payload;
     },
+    quit: (state, action) => {
+      state.login = action.payload;
+    },
   },
 });
 export default Logined;
-export const { login, logout } = Logined.actions;
+export const { login, logout, quit } = Logined.actions;


### PR DESCRIPTION
## 작업개요
- Profile 페이지 페이지네이션 리팩토링

## worklog
- 프로필의 페이지네이션에서 `totalPages`가 6이 넘어갈 경우 숫자가 변경되지 않는 현상이 생겨 하드코딩 해둔 것을 수정할 겸 리팩토링을 했습니다.
> ### 40개가 넘는 글을 작성해주신 소라님께 감사드리며...
> <img width="691" alt="스크린샷 2023-01-25 오후 1 18 17" src="https://user-images.githubusercontent.com/111413253/214492856-4461dde2-809f-4618-84be-da78d2829c0f.png">
>  근데 이제 css에 문제가 생겨보이는

## trouble shooting & 어려웠던 점
- 페이지네이션 출력되는 모습을 유동적으로 변경하기 위해 `lastNum`이 `totalPages`보다 큰 경우 개수를 조절하도록 `useState`를 사용한 변수를 도입했습니다. 그런데 `lastNum > totalPages`일 때 `setState`안에 변경할 숫자를 담아주니까 렌더링이 너무 많다는 오류를 출력을 해서 많은 애를 먹었습니다,, 🥹 ⇒ `useEffect` 안에서 실행해주니까 괜찮아졌어요! `setState`를 해줄 경우 `useEffect` 안에서 실행되어야만 렌더링 오류가 나지 않는 것 같습니다..
- 다른 사람의 6번 페이지를 보다가 바로 내 프로필로 돌아가면 6번 페이지가 그대로 기록이 남아서 내 페이지에서도 6번 게시물을 불러오는 현상이 발생했습니다.. 그래서 현재 페이지가 새로 불러온 프로필의 `totalPages`보다 클 경우 `page` 값을 1로 변경하도록 했고, 변경된 값이 페이지네이션 컴포넌트에는 적용이 안되길래 해당 부분에도 `useState`를 사용한 변수에 담긴 값을 변경하도록 설정해두었습니다. 말로 적으려니까 표현이 너무 어렵네요…
대충 다음 코드처럼 설정을 했다는 뜻..!
```js
// ProfileContent.jsx
useEffect(() => {
    axios
      .get(`${API_URL}/api/members/${userid}/matches?page=${matchPage}`)
      .then((res) => {
        setMatch(res.data.data);
        setMatchPageInfo(res.data.pageInfo);
      })
      .then(() => {
        if (matchPage > matchPageInfo?.totalPages) setMatchPage(1);
      });
  }, [matchPage, userid, matchPageInfo?.totalPages]);
```
```js
// ProfilePagination.jsx
useEffect(() => {
    if (matchFirstPage > matchPage) setMatchFirstPage(matchPage);
  }, [matchPage, matchFirstPage]);
```