### PR TITLE
[feat/fe-storyfriend] 친구 스토리 추가, 몇몇 코드 리팩토링

### DIFF
--- a/client/src/assets/arrowHistory.svg
+++ b/client/src/assets/arrowHistory.svg
@@ -1,0 +1,8 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_882_4626" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<rect width="24" height="24" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_882_4626)">
+<path d="M12 20L4 12L12 4L13.425 5.4L7.825 11H20V13H7.825L13.425 18.6L12 20Z" fill="#6A6A6B"/>
+</g>
+</svg>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,258 +1,286 @@
-import styled from 'styled-components';
-import { ReactComponent as ProfileImg } from './../assets/defaultImg.svg';
-import { ReactComponent as LogoImg } from './../assets/logoImgM.svg';
-import { ReactComponent as LogoutImg } from './../assets/logoutIcon.svg';
-import { NavLink, useNavigate } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
-import { API_URL } from '../data/apiUrl';
-import { logout } from '../redux/slice/loginstate';
-import { userInfo } from '../redux/slice/userInfo';
-import { login } from '../redux/slice/loginstate';
-import { MOBILE_POINT } from '../data/breakpoint';
-import Popup from './Popup';
+import styled from "styled-components";
+import { ReactComponent as ProfileImg } from "./../assets/defaultImg.svg";
+import { ReactComponent as LogoImg } from "./../assets/logoImgM.svg";
+import { ReactComponent as LogoutImg } from "./../assets/logoutIcon.svg";
+import { ReactComponent as BackHistory } from "./../assets/arrowHistory.svg";
+import { NavLink, useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { useState, useEffect } from "react";
+import axios from "axios";
+import { API_URL } from "../data/apiUrl";
+import { logout } from "../redux/slice/loginstate";
+import { userInfo } from "../redux/slice/userInfo";
+import { login } from "../redux/slice/loginstate";
+import { MOBILE_POINT } from "../data/breakpoint";
+import Popup from "./Popup";
 
 const HeaderWrap = styled.header`
-  position: absolute;
-  left: 0;
-  top: 0;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  width: 100%;
-  height: 112px;
-  padding: 0 48px;
+	position: absolute;
+	left: 0;
+	top: 0;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	width: 100%;
+	height: 112px;
+	padding: 0 48px;
 
-  @media (max-width: ${MOBILE_POINT}) {
-    padding: 0 16px;
-    height: 56px;
-  }
+	@media (max-width: ${MOBILE_POINT}) {
+		padding: 0 16px;
+		height: 56px;
+	}
+`;
+
+const BtnBack = styled.button`
+	display: none;
+	@media (max-width: ${MOBILE_POINT}) {
+		display: block;
+		height: 24px;
+		padding: 6px;
+		box-sizing: content-box;
+		margin-right: 6px;
+	}
 `;
 
 const LogoWrap = styled.div`
-  display: none;
-  width: 100%;
-  a {
-    display: block;
-    width: 120px;
-    height: 35px;
-    svg {
-      width: 100%;
-      height: 100%;
-    }
-  }
-  @media (max-width: ${MOBILE_POINT}) {
-    display: block;
-  }
+	display: none;
+	width: 100%;
+	a {
+		display: block;
+		width: 120px;
+		height: 35px;
+		svg {
+			width: 100%;
+			height: 100%;
+		}
+	}
+	@media (max-width: ${MOBILE_POINT}) {
+		display: block;
+	}
 `;
 
 const ProfileWrap = styled.div`
-  a {
-    flex: none;
-    display: flex;
-    align-items: center;
-  }
-  .alert {
-    display: block;
-    width: 6px;
-    height: 6px;
-    margin-right: 6px;
-    border-radius: 6px;
-    background: var(--primary-color);
-    font-size: 0;
-    overflow: hidden;
-  }
-  .user_nickname {
-    margin-right: 12px;
-    font-size: var(--font-caption-size);
-    color: var(--font-color);
-  }
-  .user_img {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    overflow: hidden;
-    img,
-    svg {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-  }
-  @media (max-width: ${MOBILE_POINT}) {
-    .user_img {
-      width: 32px;
-      height: 32px;
-      margin-right: 6px;
-    }
-    .alert,
-    .user_nickname {
-      display: none;
-    }
-  }
+	a {
+		flex: none;
+		display: flex;
+		align-items: center;
+	}
+	.alert {
+		display: block;
+		width: 6px;
+		height: 6px;
+		margin-right: 6px;
+		border-radius: 6px;
+		background: var(--primary-color);
+		font-size: 0;
+		overflow: hidden;
+	}
+	.user_nickname {
+		margin-right: 12px;
+		line-height: 1;
+		font-size: var(--font-caption-size);
+		color: var(--font-color);
+	}
+	.user_img {
+		width: 48px;
+		height: 48px;
+		margin-right: 16px;
+		border-radius: 50%;
+		overflow: hidden;
+		img,
+		svg {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+	@media (max-width: ${MOBILE_POINT}) {
+		.user_img {
+			width: 32px;
+			height: 32px;
+			margin-right: 6px;
+		}
+		.alert,
+		.user_nickname {
+			display: none;
+		}
+	}
 `;
 
 const BtnWrap = styled.div`
-  flex: none;
-  display: flex;
-  margin-left: 16px;
-  a {
-    display: block;
-    padding: 6px 16px;
-    font-size: var(--font-body2-size);
-    font-weight: var(--font-weight-md);
-    color: var(--strong-color);
-  }
-  a.active {
-    color: var(--primary-color);
-  }
-  @media (max-width: ${MOBILE_POINT}) {
-    margin-left: 6px;
-    a {
-      font-size: 12px;
-    }
-    button {
-      padding: 6px;
-    }
-  }
+	flex: none;
+	display: flex;
+	margin-left: 16px;
+	a {
+		display: block;
+		padding: 6px 16px;
+		font-size: var(--font-body2-size);
+		font-weight: var(--font-weight-md);
+		color: var(--strong-color);
+	}
+	a.active {
+		color: var(--primary-color);
+	}
+	button.btn_logout {
+		height: 24px;
+		padding: 6px;
+		box-sizing: content-box;
+	}
+	@media (max-width: ${MOBILE_POINT}) {
+		margin-left: 6px;
+		a {
+			font-size: 12px;
+		}
+	}
 `;
 
 const Header = () => {
-  const [isOpen, setIsOpen] = useState(false);
-  const loginInfo = useSelector((state) => state.islogin.login);
-  const userInform = useSelector((state) => state.userInfo.userInfo);
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
+	const [isOpen, setIsOpen] = useState(false);
+	const loginInfo = useSelector((state) => state.islogin.login);
+	const userInform = useSelector((state) => state.userInfo.userInfo);
+	const navigate = useNavigate();
+	const dispatch = useDispatch();
 
-  useEffect(() => {
-    if (loginInfo?.isLogin) {
-      axios.get(`${API_URL}/api/members/${loginInfo?.memberId}`).then((res) => {
-        dispatch(userInfo(res.data.data));
-      });
-    }
-  }, [loginInfo?.isLogin, loginInfo?.memberId, dispatch]);
+	useEffect(() => {
+		if (loginInfo?.isLogin) {
+			axios.get(`${API_URL}/api/members/${loginInfo?.memberId}`).then((res) => {
+				dispatch(userInfo(res.data.data));
+			});
+		}
+	}, [loginInfo?.isLogin, loginInfo?.memberId, dispatch]);
 
-  const handlePopup = () => {
-    setIsOpen((prev) => !prev);
-    document.body.style.overflow = 'hidden';
-  };
+	const handlePopup = () => {
+		setIsOpen((prev) => !prev);
+		document.body.style.overflow = "hidden";
+	};
 
-  const handleCancel = () => {
-    setIsOpen((prev) => !prev);
-    document.body.style.overflow = 'unset';
-  };
+	const handleCancel = () => {
+		setIsOpen((prev) => !prev);
+		document.body.style.overflow = "unset";
+	};
 
-  const handleLogout = () => {
-    axios
-      .post(
-        `${API_URL}/api/members/logout`,
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${loginInfo.accessToken}`,
-          },
-        }
-      )
-      .then(() => {
-        localStorage.clear();
-        setIsOpen((prev) => !prev);
-        document.body.style.overflow = 'unset';
-        dispatch(logout({ accessToken: null, memberId: null, isLogin: false }));
-        navigate('/');
-      });
-  };
+	const handleLogout = () => {
+		axios
+			.post(
+				`${API_URL}/api/members/logout`,
+				{},
+				{
+					headers: {
+						Authorization: `Bearer ${loginInfo.accessToken}`,
+					},
+				}
+			)
+			.then(() => {
+				localStorage.clear();
+				setIsOpen((prev) => !prev);
+				document.body.style.overflow = "unset";
+				dispatch(logout({ accessToken: null, memberId: null, isLogin: false }));
+				navigate("/");
+			});
+	};
 
-  useEffect(() => {
-    if (loginInfo?.isLogin && Date.now() >= loginInfo?.expire) {
-      const memberId = loginInfo.memberId;
-      const expire = Date.now() + 1000 * 60 * 20;
-      console.log(loginInfo.refreshtoken);
-      axios
-        .get(
-          `${API_URL}/api/members/${loginInfo?.memberId}`,
-          {
-            headers: {
-              Authorization: `Bearer ${loginInfo.accessToken}`,
-              refreshToken: `Bearer ${loginInfo.refreshtoken}`,
-            },
-          },
-          { withCredentials: true }
-        )
-        .then((res) => {
-          const refreshtoken = res.headers.refreshtoken;
-          const accessToken = res.headers.authorization;
-          dispatch(userInfo(res.data.data));
-          dispatch(
-            login({
-              accessToken,
-              memberId,
-              isLogin: true,
-              expire,
-              refreshtoken,
-            })
-          );
-          window.location.reload();
-        })
-        .catch((err) => console.log(err));
-    }
-  });
-  return (
-    <HeaderWrap>
-      <LogoWrap>
-        <a href="/" title="GAMETO">
-          <LogoImg />
-        </a>
-      </LogoWrap>
-      {userInform && loginInfo?.isLogin ? (
-        <>
-          <ProfileWrap>
-            <a href={`/profile/${loginInfo?.memberId}`}>
-              <div className="user_img">
-                {userInform.profileImage ? (
-                  <img src={userInform.profileImage} alt="프로필이미지" />
-                ) : (
-                  <ProfileImg />
-                )}
-              </div>
-              <span className="user_nickname">{userInform.nickname}</span>
-              <span className="alert">알림</span>
-            </a>
-          </ProfileWrap>
-          <BtnWrap>
-            <button onClick={handlePopup} title="로그아웃">
-              <LogoutImg />
-            </button>
-          </BtnWrap>
-          <Popup
-            isOpen={isOpen}
-            setIsOpen={setIsOpen}
-            title="로그아웃"
-            content="로그아웃 하시겠습니까?"
-            button1="로그아웃"
-            button2="취소"
-            handleBtn1={handleLogout}
-            handleBtn2={handleCancel}
-          />
-        </>
-      ) : (
-        <BtnWrap>
-          <NavLink
-            to="/signup"
-            className={({ isActive }) => (isActive ? 'active' : '')}
-          >
-            회원가입
-          </NavLink>
-          <NavLink
-            to="/login"
-            className={({ isActive }) => (isActive ? 'active' : '')}
-          >
-            로그인
-          </NavLink>
-        </BtnWrap>
-      )}
-    </HeaderWrap>
-  );
+	useEffect(() => {
+		if (loginInfo?.isLogin && Date.now() >= loginInfo?.expire) {
+			const memberId = loginInfo.memberId;
+			const expire = Date.now() + 1000 * 60 * 20;
+			console.log(loginInfo.refreshtoken);
+			axios
+				.get(
+					`${API_URL}/api/members/${loginInfo?.memberId}`,
+					{
+						headers: {
+							Authorization: `Bearer ${loginInfo.accessToken}`,
+							refreshToken: `Bearer ${loginInfo.refreshtoken}`,
+						},
+					},
+					{ withCredentials: true }
+				)
+				.then((res) => {
+					const refreshtoken = res.headers.refreshtoken;
+					const accessToken = res.headers.authorization;
+					dispatch(userInfo(res.data.data));
+					dispatch(
+						login({
+							accessToken,
+							memberId,
+							isLogin: true,
+							expire,
+							refreshtoken,
+						})
+					);
+					window.location.reload();
+				})
+				.catch((err) => console.log(err));
+		}
+	});
+
+	const handleHistoryBack = () => {
+		navigate(-1);
+	};
+
+	return (
+		<HeaderWrap>
+			<BtnBack onClick={handleHistoryBack}>
+				<BackHistory />
+			</BtnBack>
+			<LogoWrap>
+				<a href="/" title="GAMETO">
+					<LogoImg />
+				</a>
+			</LogoWrap>
+			{userInform && loginInfo?.isLogin ? (
+				<>
+					<ProfileWrap>
+						<a href={`/profile/${loginInfo?.memberId}`}>
+							<div className="user_img">
+								{userInform.profileImage ? (
+									<img src={userInform.profileImage} alt="프로필이미지" />
+								) : (
+									<ProfileImg />
+								)}
+							</div>
+							<span className="user_nickname">{userInform.nickname}</span>
+							<span className="alert">알림</span>
+						</a>
+					</ProfileWrap>
+					<BtnWrap>
+						<button
+							onClick={handlePopup}
+							title="로그아웃"
+							className="btn_logout"
+						>
+							<LogoutImg />
+						</button>
+					</BtnWrap>
+					<Popup
+						isOpen={isOpen}
+						setIsOpen={setIsOpen}
+						title="로그아웃"
+						content="로그아웃 하시겠습니까?"
+						button1="로그아웃"
+						button2="취소"
+						handleBtn1={handleLogout}
+						handleBtn2={handleCancel}
+					/>
+				</>
+			) : (
+				<BtnWrap>
+					<NavLink
+						to="/signup"
+						className={({ isActive }) => (isActive ? "active" : "")}
+					>
+						회원가입
+					</NavLink>
+					<NavLink
+						to="/login"
+						className={({ isActive }) => (isActive ? "active" : "")}
+					>
+						로그인
+					</NavLink>
+				</BtnWrap>
+			)}
+		</HeaderWrap>
+	);
 };
 
 export default Header;

--- a/client/src/components/Popup.jsx
+++ b/client/src/components/Popup.jsx
@@ -1,94 +1,102 @@
-import styled from 'styled-components';
+import styled from "styled-components";
+import { MOBILE_POINT } from "../data/breakpoint";
 
 const Background = styled.div`
-  background: rgba(229, 229, 229, 0.2);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 100;
+	background: rgba(0, 0, 0, 0.7);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 100;
 `;
 
 const PopupWrap = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin-left: 200px;
-  width: var(--col-6);
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin-left: 200px;
+	width: var(--col-6);
+
+	@media (max-width: ${MOBILE_POINT}) {
+		width: calc(100% - 32px);
+		margin: 0 auto;
+	}
 `;
 
 const Title = styled.div`
-  margin-bottom: 56px;
+	margin-bottom: 56px;
 
-  .title {
-    font-size: var(--font-head2-size);
-    font-weight: var(--font-weight-medium);
-  }
+	.title {
+		font-size: var(--font-head2-size);
+		font-weight: var(--font-weight-medium);
+	}
 `;
 
 const Content = styled.div`
-  margin-bottom: 56px;
+	margin-bottom: 56px;
 
-  .content {
-    font-size: var(--font-head3-size);
-  }
+	.content {
+		text-align: center;
+		word-break: keep-all;
+		font-size: var(--font-head3-size);
+	}
 `;
 
 const ButtonWrap = styled.div`
-  display: flex;
-  width: 100%;
-  button {
-    width: 100%;
-    margin-right: 0px;
-    :last-child {
-      margin-left: 24px;
-    }
-  }
+	display: flex;
+	width: 100%;
+	button {
+		width: 100%;
+		margin-right: 0px;
+		:last-child {
+			margin-left: 24px;
+		}
+	}
 `;
 
 const Popup = ({
-  isOpen,
-  setIsOpen,
-  title,
-  content,
-  button1,
-  button2,
-  handleBtn1,
-  handleBtn2,
+	isOpen,
+	setIsOpen,
+	title,
+	content,
+	button1,
+	button2,
+	handleBtn1,
+	handleBtn2,
 }) => {
-  const handlePopup = () => {
-    setIsOpen((prev) => !prev);
-    document.body.style.overflow = 'unset';
-  };
+	const handlePopup = () => {
+		setIsOpen((prev) => !prev);
+		document.body.style.overflow = "unset";
+	};
 
-  if (isOpen) {
-    return (
-      <Background onClick={handlePopup}>
-        <PopupWrap className="card big" onClick={(e) => e.stopPropagation()}>
-          <Title>
-            <div className="title">{title}</div>
-          </Title>
-          <Content>
-            <p className="content">{content}</p>
-          </Content>
-          <ButtonWrap>
-            <button className="em" onClick={handleBtn1}>
-              {button1}
-            </button>
-            {button2 ? (
-              <button className="normal" onClick={handleBtn2}>
-                {button2}
-              </button>
-            ) : null}
-          </ButtonWrap>
-        </PopupWrap>
-      </Background>
-    );
-  } else return null;
+	if (isOpen) {
+		return (
+			<Background onClick={handlePopup}>
+				<PopupWrap className="card big" onClick={(e) => e.stopPropagation()}>
+					<Title>
+						<div className="title">{title}</div>
+					</Title>
+					<Content>
+						<p className="content">{content}</p>
+					</Content>
+					<ButtonWrap>
+						<button className="em" onClick={handleBtn1}>
+							{button1}
+						</button>
+						{button2 ? (
+							<button className="normal" onClick={handleBtn2}>
+								{button2}
+							</button>
+						) : null}
+					</ButtonWrap>
+				</PopupWrap>
+			</Background>
+		);
+	} else return null;
 };
 
 export default Popup;

--- a/client/src/components/ProfileCard.jsx
+++ b/client/src/components/ProfileCard.jsx
@@ -1,381 +1,384 @@
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
-import styled from 'styled-components';
-import SinglePofileWrap from './SingleProfileWrap';
-import { ReactComponent as Setting } from '../assets/settingsIcon.svg';
-import { ReactComponent as Heart } from '../assets/heartIcon.svg';
-import { ReactComponent as EmptyHeart } from '../assets/heartEmptyIcon.svg';
-import axios from 'axios';
-import { API_URL } from '../data/apiUrl';
-import { useState, useEffect } from 'react';
-import { setProfile } from '../redux/slice/profileSlice';
-import { MOBILE_POINT } from '../data/breakpoint';
-import Popup from './Popup';
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import SinglePofileWrap from "./SingleProfileWrap";
+import { ReactComponent as Setting } from "../assets/settingsIcon.svg";
+import { ReactComponent as Heart } from "../assets/heartIcon.svg";
+import { ReactComponent as EmptyHeart } from "../assets/heartEmptyIcon.svg";
+import axios from "axios";
+import { API_URL } from "../data/apiUrl";
+import { useState, useEffect } from "react";
+import { setProfile } from "../redux/slice/profileSlice";
+import { MOBILE_POINT } from "../data/breakpoint";
+import Popup from "./Popup";
 
 const ProfileWrap = styled.div`
-  width: var(--col-4);
-  margin-bottom: 16px;
-  .inform_title {
-    margin-bottom: 10px;
-    font-size: var(--font-body2-size);
-    font-weight: var(--font-weight-medium);
-  }
-  .inform_content {
-    margin-top: 6px;
-    font-size: var(--font-body2-size);
-    color: var(--white);
-    white-space: pre-wrap;
-  }
+	width: var(--col-4);
+	margin-bottom: 16px;
+	.inform_title {
+		margin-bottom: 10px;
+		font-size: var(--font-body2-size);
+		font-weight: var(--font-weight-medium);
+	}
+	.inform_content {
+		margin-top: 6px;
+		font-size: var(--font-body2-size);
+		color: var(--white);
+		white-space: pre-wrap;
+	}
 
-  @media (max-width: ${MOBILE_POINT}) {
-    width: 100%;
-  }
+	@media (max-width: ${MOBILE_POINT}) {
+		width: 100%;
+	}
 `;
 
 const InformWrap = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 16px;
-  .profile_container {
-    margin-bottom: 0px;
-  }
-  .icon {
-    margin: auto 0;
-  }
-  .setting,
-  .likes {
-    width: 24px;
-    height: 24px;
-    margin: auto 0;
-    cursor: pointer;
-  }
+	display: flex;
+	justify-content: space-between;
+	margin-bottom: 16px;
+	.profile_container {
+		margin-bottom: 0px;
+	}
+	.icon {
+		margin: auto 0;
+	}
+	.setting,
+	.likes {
+		width: 24px;
+		height: 24px;
+		margin: auto 0;
+		cursor: pointer;
+	}
 `;
 
 const FollowWrap = styled.div`
-  display: flex;
-  justify-content: space-between;
-  padding: 16px 0;
+	display: flex;
+	justify-content: space-between;
+	padding: 16px 0;
 `;
 
 const Follow = styled.div`
-  text-align: center;
-  .follow,
-  .number {
-    font-size: var(--font-body2-size);
-    line-height: var(--line-height-lg);
-  }
-  .number {
-    color: var(--white);
-  }
+	text-align: center;
+	.follow,
+	.number {
+		font-size: var(--font-body2-size);
+		line-height: var(--line-height-lg);
+	}
+	.number {
+		color: var(--white);
+	}
 `;
 
 const ButtonWrap = styled.div`
-  display: flex;
-  flex-direction: column;
-  button {
-    margin-top: 16px;
-  }
+	display: flex;
+	flex-direction: column;
+	button {
+		margin-top: 16px;
+	}
 `;
 
 const GameWrap = styled.div`
-  ul {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  .game_title {
-    margin: 6px 6px 0 0;
-    padding: 8px 12px;
-    background: var(--bg-color);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-btn);
-    color: var(--yellow);
-    font-size: var(--font-caption-size);
-  }
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+	}
+	.game_title {
+		margin: 6px 6px 0 0;
+		padding: 8px 12px;
+		background: var(--bg-color);
+		border: 1px solid var(--border-color);
+		border-radius: var(--border-radius-btn);
+		color: var(--yellow);
+		font-size: var(--font-caption-size);
+	}
 `;
 
 const ProfileCard = () => {
-  const [isLikeOpen, setIsLikeOpen] = useState(false);
-  const [isFollowOpen, setIsFollowOpen] = useState(false);
-  const [isBlockOpen, setIsBlockOpen] = useState(false);
-  const [user, setUser] = useState(null);
-  const [isMe, setIsMe] = useState(false);
-  const { userid } = useParams();
-  const loginInfo = useSelector((state) => state.islogin.login);
-  const userInfo = useSelector((state) => state.profile.user);
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
+	const [isLikeOpen, setIsLikeOpen] = useState(false);
+	const [isFollowOpen, setIsFollowOpen] = useState(false);
+	const [isBlockOpen, setIsBlockOpen] = useState(false);
+	const [user, setUser] = useState(null);
+	const [isMe, setIsMe] = useState(false);
+	const { userid } = useParams();
+	const loginInfo = useSelector((state) => state.islogin.login);
+	const userInfo = useSelector((state) => state.profile.user);
+	const navigate = useNavigate();
+	const dispatch = useDispatch();
 
-  const handleLogin = () => {
-    if (isLikeOpen) {
-      setIsLikeOpen((prev) => !prev);
-    }
-    if (isFollowOpen) {
-      setIsFollowOpen((prev) => !prev);
-    }
-    if (isBlockOpen) {
-      setIsBlockOpen((prev) => !prev);
-    }
-    document.body.style.overflow = 'unset';
-    navigate(`/login`);
-  };
+	const handleLogin = () => {
+		if (isLikeOpen) {
+			setIsLikeOpen((prev) => !prev);
+		}
+		if (isFollowOpen) {
+			setIsFollowOpen((prev) => !prev);
+		}
+		if (isBlockOpen) {
+			setIsBlockOpen((prev) => !prev);
+		}
+		document.body.style.overflow = "unset";
+		navigate(`/login`);
+	};
 
-  const handleSignup = () => {
-    if (isLikeOpen) {
-      setIsLikeOpen((prev) => !prev);
-    }
-    if (isFollowOpen) {
-      setIsFollowOpen((prev) => !prev);
-    }
-    if (isBlockOpen) {
-      setIsBlockOpen((prev) => !prev);
-    }
-    document.body.style.overflow = 'unset';
-    navigate(`/signup`);
-  };
+	const handleSignup = () => {
+		if (isLikeOpen) {
+			setIsLikeOpen((prev) => !prev);
+		}
+		if (isFollowOpen) {
+			setIsFollowOpen((prev) => !prev);
+		}
+		if (isBlockOpen) {
+			setIsBlockOpen((prev) => !prev);
+		}
+		document.body.style.overflow = "unset";
+		navigate(`/signup`);
+	};
 
-  const handleFollow = () => {
-    if (loginInfo?.isLogin) {
-      axios
-        .post(
-          `${API_URL}/api/members/${userid}/follows`,
-          {},
-          {
-            headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-          }
-        )
-        .then((res) => {
-          if (res.data === '팔로우가 완료되었습니다.') {
-            dispatch(
-              setProfile({
-                ...userInfo,
-                followStatus: !userInfo.followStatus,
-                followerCount: userInfo.followerCount + 1,
-              })
-            );
-          } else {
-            dispatch(
-              setProfile({
-                ...userInfo,
-                followStatus: !userInfo.followStatus,
-                followerCount: userInfo.followerCount - 1,
-              })
-            );
-          }
-        });
-    } else {
-      setIsFollowOpen((prev) => !prev);
-      document.body.style.overflow = 'hidden';
-    }
-  };
+	const handleFollow = () => {
+		if (loginInfo?.isLogin) {
+			axios
+				.post(
+					`${API_URL}/api/members/${userid}/follows`,
+					{},
+					{
+						headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+					}
+				)
+				.then((res) => {
+					if (res.data === "팔로우가 완료되었습니다.") {
+						dispatch(
+							setProfile({
+								...userInfo,
+								followStatus: !userInfo.followStatus,
+								followerCount: userInfo.followerCount + 1,
+							})
+						);
+					} else {
+						dispatch(
+							setProfile({
+								...userInfo,
+								followStatus: !userInfo.followStatus,
+								followerCount: userInfo.followerCount - 1,
+							})
+						);
+					}
+				});
+		} else {
+			setIsFollowOpen((prev) => !prev);
+			document.body.style.overflow = "hidden";
+		}
+	};
 
-  const handleLike = () => {
-    if (loginInfo?.isLogin) {
-      axios
-        .post(
-          `${API_URL}/api/members/${userid}/likes`,
-          {},
-          {
-            headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-          }
-        )
-        .then((res) => {
-          if (res.data === '좋아요가 완료되었습니다.') {
-            dispatch(
-              setProfile({
-                ...userInfo,
-                likeStatus: !userInfo.likeStatus,
-                likeCount: userInfo.likeCount + 1,
-              })
-            );
-          } else {
-            dispatch(
-              setProfile({
-                ...userInfo,
-                likeStatus: !userInfo.likeStatus,
-                likeCount: userInfo.likeCount - 1,
-              })
-            );
-          }
-        });
-    } else {
-      setIsLikeOpen((prev) => !prev);
-      document.body.style.overflow = 'hidden';
-    }
-  };
+	const handleLike = () => {
+		if (loginInfo?.isLogin) {
+			axios
+				.post(
+					`${API_URL}/api/members/${userid}/likes`,
+					{},
+					{
+						headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+					}
+				)
+				.then((res) => {
+					if (res.data === "좋아요가 완료되었습니다.") {
+						dispatch(
+							setProfile({
+								...userInfo,
+								likeStatus: !userInfo.likeStatus,
+								likeCount: userInfo.likeCount + 1,
+							})
+						);
+					} else {
+						dispatch(
+							setProfile({
+								...userInfo,
+								likeStatus: !userInfo.likeStatus,
+								likeCount: userInfo.likeCount - 1,
+							})
+						);
+					}
+				});
+		} else {
+			setIsLikeOpen((prev) => !prev);
+			document.body.style.overflow = "hidden";
+		}
+	};
 
-  const handleBlock = () => {
-    if (loginInfo?.isLogin) {
-      axios
-        .post(
-          `${API_URL}/api/members/${userid}/blocks`,
-          {},
-          {
-            headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-          }
-        )
-        .then((res) => {
-          if (
-            res.data ===
-            '해당 유저를 차단하셨습니다. 팔로우와 좋아요가 취소됩니다.'
-          ) {
-            dispatch(
-              setProfile({
-                ...userInfo,
-                blockStatus: !userInfo.blockStatus,
-              })
-            );
-          } else {
-            dispatch(
-              setProfile({
-                ...userInfo,
-                blockStatus: !userInfo.blockStatus,
-              })
-            );
-          }
-        });
-    } else {
-      setIsBlockOpen((prev) => !prev);
-      document.body.style.overflow = 'hidden';
-    }
-  };
+	const handleBlock = () => {
+		if (loginInfo?.isLogin) {
+			axios
+				.post(
+					`${API_URL}/api/members/${userid}/blocks`,
+					{},
+					{
+						headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+					}
+				)
+				.then((res) => {
+					if (
+						res.data ===
+						"해당 유저를 차단하셨습니다. 팔로우와 좋아요가 취소됩니다."
+					) {
+						dispatch(
+							setProfile({
+								...userInfo,
+								blockStatus: !userInfo.blockStatus,
+							})
+						);
+					} else {
+						dispatch(
+							setProfile({
+								...userInfo,
+								blockStatus: !userInfo.blockStatus,
+							})
+						);
+					}
+				});
+		} else {
+			setIsBlockOpen((prev) => !prev);
+			document.body.style.overflow = "hidden";
+		}
+	};
 
-  useEffect(() => {
-    if (loginInfo?.accessToken) {
-      axios
-        .get(`${API_URL}/api/members/${userid}`, {
-          headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
-        })
-        .then((res) => {
-          setUser(res.data.data);
-          dispatch(setProfile(res.data.data));
-        });
-    } else {
-      axios.get(`${API_URL}/api/members/${userid}`).then((res) => {
-        setUser(res.data.data);
-        dispatch(setProfile(res.data.data));
-      });
-    }
-    Number(userid) === loginInfo?.memberId ? setIsMe(true) : setIsMe(false);
-  }, [userid, loginInfo?.accessToken, loginInfo?.memberId, dispatch]);
+	useEffect(() => {
+		if (loginInfo?.accessToken) {
+			axios
+				.get(`${API_URL}/api/members/${userid}`, {
+					headers: { Authorization: `Bearer ${loginInfo?.accessToken}` },
+				})
+				.then((res) => {
+					setUser(res.data.data);
+					dispatch(setProfile(res.data.data));
+				});
+		} else {
+			axios.get(`${API_URL}/api/members/${userid}`).then((res) => {
+				setUser(res.data.data);
+				dispatch(setProfile(res.data.data));
+			});
+		}
+		Number(userid) === loginInfo?.memberId ? setIsMe(true) : setIsMe(false);
+	}, [userid, loginInfo?.accessToken, loginInfo?.memberId, dispatch]);
 
-  if (user) {
-    return (
-      <div>
-        <ProfileWrap className="card sm">
-          <InformWrap>
-            <SinglePofileWrap
-              className="profile_container"
-              imgSize="big"
-              imgSrc={user.profileImage}
-              name={user.nickname}
-              subInfo={user.identifier}
-            />
-            {/* 자기 자신 여부에 따라 표시 아이콘 달라짐 */}
-            {isMe ? (
-              <div className="icon">
-                <Link to={`/profile/${userid}/edit`}>
-                  <Setting className="setting" />
-                </Link>
-              </div>
-            ) : (
-              <div className="icon">
-                {userInfo.blockStatus ? null : (
-                  <>
-                    {userInfo.likeStatus ? (
-                      <Heart className="likes" onClick={handleLike} />
-                    ) : (
-                      <EmptyHeart className="likes" onClick={handleLike} />
-                    )}
-                  </>
-                )}
-              </div>
-            )}
-          </InformWrap>
-          <FollowWrap>
-            <Follow>
-              <div className="follow">팔로잉</div>
-              <div className="number">{userInfo.followingCount}</div>
-            </Follow>
-            <Follow>
-              <div className="follow">팔로워</div>
-              <div className="number">{userInfo.followerCount}</div>
-            </Follow>
-            <Follow>
-              <div className="follow">좋아요</div>
-              <div className="number">{userInfo.likeCount}</div>
-            </Follow>
-          </FollowWrap>
-          {!isMe ? (
-            <ButtonWrap>
-              {userInfo.blockStatus ? null : (
-                <>
-                  {userInfo.followStatus ? (
-                    <button className="em" onClick={handleFollow}>
-                      팔로우 해제하기
-                    </button>
-                  ) : (
-                    <button className="em" onClick={handleFollow}>
-                      팔로우하기
-                    </button>
-                  )}
-                  <button className="normal" onClick={handleBlock}>
-                    차단하기
-                  </button>
-                </>
-              )}
-            </ButtonWrap>
-          ) : null}
-        </ProfileWrap>
-        {userInfo.blockStatus ? null : (
-          <>
-            <ProfileWrap className="card sm">
-              <div className="inform_title">주로하는 게임</div>
-              <GameWrap>
-                <ul>
-                  {user.games.map((game) => (
-                    <li key={game.id} className="normal game_title">
-                      {game.korTitle}
-                    </li>
-                  ))}
-                </ul>
-              </GameWrap>
-            </ProfileWrap>
-            <ProfileWrap className="card sm">
-              <div className="inform_title">자기 소개</div>
-              <div className="inform_content">{user.introduction}</div>
-            </ProfileWrap>
-          </>
-        )}
-        <Popup
-          isOpen={isLikeOpen}
-          title="좋아요"
-          content="좋아요는 로그인 후 이용 가능합니다."
-          button1="로그인"
-          button2="회원가입"
-          handleBtn1={handleLogin}
-          handleBtn2={handleSignup}
-        />
-        <Popup
-          isOpen={isFollowOpen}
-          title="팔로우"
-          content="팔로우는 로그인 후 이용 가능합니다."
-          button1="로그인"
-          button2="회원가입"
-          handleBtn1={handleLogin}
-          handleBtn2={handleSignup}
-        />
-        <Popup
-          isOpen={isBlockOpen}
-          title="차단"
-          content="차단은 로그인 후 이용 가능합니다."
-          button1="로그인"
-          button2="회원가입"
-          handleBtn1={handleLogin}
-          handleBtn2={handleSignup}
-        />
-      </div>
-    );
-  } else return null;
+	if (user) {
+		return (
+			<div>
+				<ProfileWrap className="card sm">
+					<InformWrap>
+						<SinglePofileWrap
+							className="profile_container"
+							imgSize="big"
+							imgSrc={user.profileImage}
+							name={user.nickname}
+							subInfo={user.identifier}
+						/>
+						{/* 자기 자신 여부에 따라 표시 아이콘 달라짐 */}
+						{isMe ? (
+							<div className="icon">
+								<Link to={`/profile/${userid}/edit`}>
+									<Setting className="setting" />
+								</Link>
+							</div>
+						) : (
+							<div className="icon">
+								{userInfo.blockStatus ? null : (
+									<>
+										{userInfo.likeStatus ? (
+											<Heart className="likes" onClick={handleLike} />
+										) : (
+											<EmptyHeart className="likes" onClick={handleLike} />
+										)}
+									</>
+								)}
+							</div>
+						)}
+					</InformWrap>
+					<FollowWrap>
+						<Follow>
+							<div className="follow">팔로잉</div>
+							<div className="number">{userInfo.followingCount}</div>
+						</Follow>
+						<Follow>
+							<div className="follow">팔로워</div>
+							<div className="number">{userInfo.followerCount}</div>
+						</Follow>
+						<Follow>
+							<div className="follow">좋아요</div>
+							<div className="number">{userInfo.likeCount}</div>
+						</Follow>
+					</FollowWrap>
+					{!isMe ? (
+						<ButtonWrap>
+							{userInfo.blockStatus ? null : (
+								<>
+									{userInfo.followStatus ? (
+										<button className="em" onClick={handleFollow}>
+											팔로우 해제하기
+										</button>
+									) : (
+										<button className="em" onClick={handleFollow}>
+											팔로우하기
+										</button>
+									)}
+									<button className="normal" onClick={handleBlock}>
+										차단하기
+									</button>
+								</>
+							)}
+						</ButtonWrap>
+					) : null}
+				</ProfileWrap>
+				{userInfo.blockStatus ? null : (
+					<>
+						<ProfileWrap className="card sm">
+							<div className="inform_title">주로하는 게임</div>
+							<GameWrap>
+								<ul>
+									{user.games.map((game) => (
+										<li key={game.id} className="normal game_title">
+											{game.korTitle}
+										</li>
+									))}
+								</ul>
+							</GameWrap>
+						</ProfileWrap>
+						<ProfileWrap className="card sm">
+							<div className="inform_title">자기 소개</div>
+							<div className="inform_content">{user.introduction}</div>
+						</ProfileWrap>
+					</>
+				)}
+				<Popup
+					isOpen={isLikeOpen}
+					setIsOpen={setIsLikeOpen}
+					title="좋아요"
+					content="좋아요는 로그인 후 이용 가능합니다."
+					button1="로그인"
+					button2="회원가입"
+					handleBtn1={handleLogin}
+					handleBtn2={handleSignup}
+				/>
+				<Popup
+					isOpen={isFollowOpen}
+					setIsOpen={setIsFollowOpen}
+					title="팔로우"
+					content="팔로우는 로그인 후 이용 가능합니다."
+					button1="로그인"
+					button2="회원가입"
+					handleBtn1={handleLogin}
+					handleBtn2={handleSignup}
+				/>
+				<Popup
+					isOpen={isBlockOpen}
+					setIsOpen={setIsBlockOpen}
+					title="차단"
+					content="차단은 로그인 후 이용 가능합니다."
+					button1="로그인"
+					button2="회원가입"
+					handleBtn1={handleLogin}
+					handleBtn2={handleSignup}
+				/>
+			</div>
+		);
+	} else return null;
 };
 
 export default ProfileCard;

--- a/client/src/components/StoryAll.jsx
+++ b/client/src/components/StoryAll.jsx
@@ -1,0 +1,126 @@
+import styled from "styled-components";
+import { useEffect, useState, useRef } from "react";
+import axios from "axios";
+import { API_URL } from "../data/apiUrl";
+import SearchBar from "./../components/SearchBar";
+import StorySingle from "../components/StorySingle";
+import NoSearch from "../components/NoSearch";
+
+const StoryBoardWrap = styled.div`
+	margin-top: 48px;
+	> div {
+		margin-bottom: 24px;
+	}
+`;
+
+const StoryAll = ({ accessToken, isLogin }) => {
+	const [storyData, setStoryData] = useState([]);
+	const [keyword, setKeyword] = useState("");
+	const [isNoSearch, setIsNoSearch] = useState(false);
+
+	//페이지 로딩 state
+	const [page, setPage] = useState(1);
+	const [isLoading, setIsLoading] = useState(false);
+	const pageEndPoint = useRef();
+	//페이지 증가 함수
+	const addPage = () => {
+		setPage((prevPage) => {
+			return prevPage + 1;
+		});
+	};
+	//페이지 요청 함수
+	const requestPage = async (page) => {
+		let config = {};
+		let url = "";
+		if (isLogin) {
+			config = {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			};
+		}
+
+		if (keyword === "") {
+			if (page === 1) setStoryData([]);
+			url = `${API_URL}/api/boards?page=${page}`;
+			await axios
+				.get(url, config)
+				.then((res) => {
+					setStoryData((prevData) => [...prevData, ...res.data.data]);
+					const totalPages = res.data.pageInfo.totalPages;
+					if (page === totalPages) {
+						setIsLoading(false);
+					} else {
+						setIsLoading(true);
+					}
+				})
+				.catch((err) => {
+					console.log(err);
+				});
+		} else {
+			url = `${API_URL}/api/boards?page=${page}&keyword=${keyword}`;
+			await axios
+				.get(url, config)
+				.then((res) => {
+					//console.log(res.data.data);
+					setStoryData(res.data.data);
+					const totalPages = res.data.pageInfo.totalPages;
+
+					if (page === totalPages) {
+						setIsLoading(false);
+					} else {
+						setIsLoading(true);
+					}
+				})
+				.catch((err) => {
+					// console.log(err);
+					setIsNoSearch(true);
+					setIsLoading(false);
+				});
+		}
+	};
+	//페이지 바뀔때마다 데이터 요청
+	useEffect(() => {
+		requestPage(page);
+	}, [page, keyword]);
+	//Intersection Observer로 로딩 여부 확인
+	useEffect(() => {
+		if (isLoading) {
+			//로딩시 페이지 추가
+			const observer = new IntersectionObserver(
+				(entries) => {
+					if (entries[0].isIntersecting) {
+						addPage();
+					}
+				},
+				{ threshold: 0.4 }
+			);
+			//옵저버 탐색
+			observer.observe(pageEndPoint.current);
+		}
+	}, [isLoading]);
+
+	return (
+		<>
+			<SearchBar setKeyword={setKeyword} setPage={setPage} />
+			<StoryBoardWrap>
+				{keyword && isNoSearch ? <NoSearch /> : null}
+				{storyData
+					? storyData.map((el, idx) => {
+							return <StorySingle key={idx} data={el} />;
+					  })
+					: "작성된 스토리가 없습니다."}
+				{isLoading && (
+					<div className="loadingObserver" ref={pageEndPoint}>
+						<div></div>
+						<div></div>
+						<div></div>
+						<div></div>
+						<div></div>
+					</div>
+				)}
+			</StoryBoardWrap>
+		</>
+	);
+};
+export default StoryAll;

--- a/client/src/components/StoryFileView.jsx
+++ b/client/src/components/StoryFileView.jsx
@@ -15,10 +15,13 @@ const ImgArea = styled.div`
 		${(props) => (props.size === "big" ? "" : "height: 100%;")}
 		${(props) => (props.size === "big" ? "" : "object-fit: cover;")}
 		${(props) => (props.size === "big" ? "max-width:100%;" : "")}
+		display: block;
 	}
 
 	@media (max-width: ${MOBILE_POINT}) {
 		width: 100%;
+		height: auto;
+		margin-top: 16px;
 	}
 `;
 
@@ -38,6 +41,7 @@ const VideoArea = styled.div`
 
 	@media (max-width: ${MOBILE_POINT}) {
 		width: 100%;
+		margin-top: 16px;
 	}
 `;
 

--- a/client/src/components/StoryFriend.jsx
+++ b/client/src/components/StoryFriend.jsx
@@ -1,0 +1,135 @@
+import styled from "styled-components";
+import { useEffect, useState, useRef } from "react";
+import axios from "axios";
+import { API_URL } from "../data/apiUrl";
+import SearchBar from "./../components/SearchBar";
+import StorySingle from "../components/StorySingle";
+import NoSearch from "../components/NoSearch";
+
+const StoryBoardWrap = styled.div`
+	margin-top: 48px;
+	> div {
+		margin-bottom: 24px;
+	}
+`;
+
+const StoryFriend = ({ accessToken, isLogin }) => {
+	const [storyData, setStoryData] = useState([]);
+	const [keyword, setKeyword] = useState("");
+	const [isNoSearch, setIsNoSearch] = useState(false);
+	const [isNoFriends, setIsNoFrends] = useState(false);
+
+	//페이지 로딩 state
+	const [page, setPage] = useState(1);
+	const [isLoading, setIsLoading] = useState(false);
+	const pageEndPoint = useRef();
+	//페이지 증가 함수
+	const addPage = () => {
+		setPage((prevPage) => {
+			return prevPage + 1;
+		});
+	};
+	//페이지 요청 함수
+	const requestPage = async (page) => {
+		let config = {};
+		let url = "";
+		if (isLogin) {
+			config = {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			};
+		} else {
+			return;
+		}
+
+		if (keyword === "") {
+			if (page === 1) setStoryData([]);
+			url = `${API_URL}/api/boards/following?page=${page}`;
+			await axios
+				.get(url, config)
+				.then((res) => {
+					setStoryData((prevData) => [...prevData, ...res.data.data]);
+					const totalPages = res.data.pageInfo.totalPages;
+					if (totalPages === 0) {
+						setStoryData([]);
+						setIsLoading(false);
+						setIsNoFrends(true);
+						return;
+					}
+					if (page === totalPages) {
+						setIsLoading(false);
+						return;
+					} else {
+						setIsLoading(true);
+					}
+				})
+				.catch((err) => {
+					console.log(err);
+				});
+		} else {
+			url = `${API_URL}/api/boards/following?page=${page}&keyword=${keyword}`;
+			await axios
+				.get(url, config)
+				.then((res) => {
+					setStoryData(res.data.data);
+					const totalPages = res.data.pageInfo.totalPages;
+
+					if (page === totalPages) {
+						setIsLoading(false);
+					} else {
+						setIsLoading(true);
+					}
+				})
+				.catch((err) => {
+					setIsNoSearch(true);
+					setIsLoading(false);
+				});
+		}
+	};
+	//페이지 바뀔때마다 데이터 요청
+	useEffect(() => {
+		requestPage(page);
+	}, [page, keyword]);
+	//Intersection Observer로 로딩 여부 확인
+	useEffect(() => {
+		if (isLoading) {
+			//로딩시 페이지 추가
+			const observer = new IntersectionObserver(
+				(entries) => {
+					if (entries[0].isIntersecting) {
+						addPage();
+					}
+				},
+				{ threshold: 0.4 }
+			);
+			//옵저버 탐색
+			observer.observe(pageEndPoint.current);
+		}
+	}, [isLoading]);
+
+	return (
+		<>
+			<SearchBar setKeyword={setKeyword} setPage={setPage} />
+			<StoryBoardWrap>
+				{keyword && isNoSearch ? <NoSearch /> : null}
+				{storyData
+					? storyData.map((el, idx) => {
+							return <StorySingle key={idx} data={el} />;
+					  })
+					: "친구의 스토리가 없습니다."}
+				{isNoFriends ? "친구가 없습니다..." : null}
+				{isLoading && (
+					<div className="loadingObserver" ref={pageEndPoint}>
+						<div></div>
+						<div></div>
+						<div></div>
+						<div></div>
+						<div></div>
+					</div>
+				)}
+			</StoryBoardWrap>
+		</>
+	);
+};
+export default StoryFriend;

--- a/client/src/components/StorySingle.jsx
+++ b/client/src/components/StorySingle.jsx
@@ -1,138 +1,138 @@
-import styled from 'styled-components';
-import { ReactComponent as BoardLikeIcon } from './../assets/heartIcon.svg';
-import { ReactComponent as BoardCommentIcon } from './../assets/sms.svg';
-import { Link, useNavigate } from 'react-router-dom';
-import displayedAt from '../util/displayedAt';
-import SinglePofileWrap from './SingleProfileWrap';
-import StoryFileView from './StoryFileView';
-import { useSelector } from 'react-redux';
-import { useState } from 'react';
+import styled from "styled-components";
+import { ReactComponent as BoardLikeIcon } from "./../assets/heartIcon.svg";
+import { ReactComponent as BoardCommentIcon } from "./../assets/sms.svg";
+import { Link, useNavigate } from "react-router-dom";
+import displayedAt from "../util/displayedAt";
+import SinglePofileWrap from "./SingleProfileWrap";
+import StoryFileView from "./StoryFileView";
+import { useSelector } from "react-redux";
+import { useState } from "react";
 import { MOBILE_POINT } from "../data/breakpoint";
-import Popup from './Popup';
+import Popup from "./Popup";
 
 const StoryWrap = styled.div`
-  cursor: pointer;
-  .storyMain {
-    display: flex;
-  }
-  @media (max-width: ${MOBILE_POINT}) {
+	cursor: pointer;
+	.storyMain {
+		display: flex;
+	}
+	@media (max-width: ${MOBILE_POINT}) {
 		.storyMain {
 			flex-direction: column;
 		}
-		.story_list_flieview {
-			width: 100%;
-			margin-top: 16px;
-		}
-  }
+	}
 `;
 
 const TextArea = styled.div`
-  flex: 1;
-  margin-right: 32px;
+	flex: 1;
+	margin-right: 32px;
 
-  .content {
-    font-size: var(--font-body2-size);
-  }
+	.content {
+		font-size: var(--font-body2-size);
+	}
 `;
 
 const InfoWrap = styled.ul`
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
 
-  li {
-    display: flex;
-    align-items: center;
-    padding: 10px 16px;
-    margin-top: 32px;
-    margin-right: 16px;
-    border-radius: 100px;
-    background: var(--grey);
-    color: var(--strong-color);
-    font-size: var(--font-body2-size);
+	li {
+		display: flex;
+		align-items: center;
+		padding: 10px 16px;
+		margin-top: 32px;
+		margin-right: 16px;
+		border-radius: 100px;
+		background: var(--grey);
+		color: var(--strong-color);
+		font-size: var(--font-body2-size);
 
-    svg {
-      width: 16px;
-      height: 16px;
-      margin-right: 8px;
-    }
-  }
-  li:last-child {
-    margin-right: 0;
-  }
+		svg {
+			width: 16px;
+			height: 16px;
+			margin-right: 8px;
+		}
+	}
+	li:last-child {
+		margin-right: 0;
+	}
 `;
 
 const StorySingle = ({ data }) => {
-  const navigate = useNavigate();
-  const loginInfo = useSelector((state) => state.islogin.login);
-  const [isOpen, setIsOpen] = useState(false);
+	const navigate = useNavigate();
+	const loginInfo = useSelector((state) => state.islogin.login);
+	const [isOpen, setIsOpen] = useState(false);
 
-  const handleLogin = () => {
-    navigate(`/login`);
-  };
+	const handleLogin = () => {
+		navigate(`/login`);
+	};
 
-  const handleSignup = () => {
-    navigate(`/signup`);
-  };
+	const handleSignup = () => {
+		navigate(`/signup`);
+	};
 
-  const handleNaviOnClick = (e, memberId, boardId) => {
-    if (loginInfo?.isLogin) {
-      navigate(`/story/${memberId}/${boardId}`);
-    } else {
-      setIsOpen((prev) => !prev);
-    }
-  };
+	const handleNaviOnClick = (e, memberId, boardId) => {
+		if (loginInfo?.isLogin) {
+			navigate(`/story/${memberId}/${boardId}`);
+		} else {
+			setIsOpen((prev) => !prev);
+			document.body.style.overflow = "hidden";
+		}
+	};
 
-  const handleProfileClick = (e, memberId) => {
-    e.stopPropagation();
-    navigate(`/profile/${memberId}`);
-  };
+	const handleProfileClick = (e, memberId) => {
+		e.stopPropagation();
+		navigate(`/profile/${memberId}`);
+	};
 
-  return (
-    <StoryWrap
-      className="card md"
-      onClick={(e) => handleNaviOnClick(e, data.memberId, data.id)}
-    >
-      <div className="storyMain">
-        <TextArea>
-          <div onClick={(e) => handleProfileClick(e, data.memberId)} title="">
-            <SinglePofileWrap
-              imgSrc={data.profileImage}
-              name={data.nickname}
-              subInfo={displayedAt(data.createdAt)}
-            />
-          </div>
-          <div className="content">{data.content}</div>
-        </TextArea>
-        <StoryFileView
-          fileName={data.uploadFileName}
-          contentType={data.contentType}
-        />
-      </div>
-      <InfoWrap>
-        {data.likeCount ? (
-          <li>
-            <BoardLikeIcon />
-            <span>{data.likeCount}</span>
-          </li>
-        ) : null}
-        {data.commentCount ? (
-          <li>
-            <BoardCommentIcon />
-            <span>{data.commentCount}</span>
-          </li>
-        ) : null}
-      </InfoWrap>
-      <Popup
-        isOpen={isOpen}
-        title="스토리 상세보기"
-        content="스토리는 상세보기는 로그인 후 가능합니다."
-        button1="로그인"
-        button2="회원가입"
-        handleBtn1={handleLogin}
-        handleBtn2={handleSignup}
-      />
-    </StoryWrap>
-  );
+	return (
+		<>
+			<StoryWrap
+				className="card md"
+				onClick={(e) => handleNaviOnClick(e, data.memberId, data.id)}
+			>
+				<div className="storyMain">
+					<TextArea>
+						<div onClick={(e) => handleProfileClick(e, data.memberId)} title="">
+							<SinglePofileWrap
+								imgSrc={data.profileImage}
+								name={data.nickname}
+								subInfo={displayedAt(data.createdAt)}
+							/>
+						</div>
+						<div className="content">{data.content}</div>
+					</TextArea>
+					<StoryFileView
+						fileName={data.uploadFileName}
+						contentType={data.contentType}
+					/>
+				</div>
+				<InfoWrap>
+					{data.likeCount ? (
+						<li>
+							<BoardLikeIcon />
+							<span>{data.likeCount}</span>
+						</li>
+					) : null}
+					{data.commentCount ? (
+						<li>
+							<BoardCommentIcon />
+							<span>{data.commentCount}</span>
+						</li>
+					) : null}
+				</InfoWrap>
+			</StoryWrap>
+			<Popup
+				isOpen={isOpen}
+				setIsOpen={setIsOpen}
+				title="스토리 상세보기"
+				content="스토리는 상세보기는 로그인 후 가능합니다."
+				button1="로그인"
+				button2="회원가입"
+				handleBtn1={handleLogin}
+				handleBtn2={handleSignup}
+			/>
+		</>
+	);
 };
 export default StorySingle;

--- a/client/src/data/apiUrl.js
+++ b/client/src/data/apiUrl.js
@@ -1,1 +1,1 @@
-export const API_URL = `https://port-0-seb41-main-033-1jx7m2gld2o3uit.gksl2.cloudtype.app`;
+export const API_URL = `https://port-0-server-1jx7m2gld2o3uit.gksl2.cloudtype.app`;

--- a/client/src/pages/Story.jsx
+++ b/client/src/pages/Story.jsx
@@ -1,14 +1,11 @@
 import styled from "styled-components";
-import SearchBar from "./../components/SearchBar";
-import StorySingle from "../components/StorySingle";
 import WriteFloatButton from "../components/WriteFloatButton";
-import { useEffect, useState, useRef } from "react";
-import axios from "axios";
-import { API_URL } from "../data/apiUrl";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
 import Popup from "../components/Popup";
-import NoSearch from "../components/NoSearch";
+import StoryAll from "../components/StoryAll";
+import StoryFriend from "../components/StoryFriend";
 
 const Wrap = styled.div`
 	.loadingObserver {
@@ -42,17 +39,11 @@ const TitleWrap = styled.div`
 		margin-right: 24px;
 		letter-spacing: -0.5px;
 		font-size: var(--font-head2-size);
+		cursor: pointer;
 	}
 	h3.active {
 		font-weight: var(--font-weight-medium);
 		color: var(--primary-color);
-	}
-`;
-
-const StoryBoardWrap = styled.div`
-	margin-top: 48px;
-	> div {
-		margin-bottom: 24px;
 	}
 `;
 
@@ -61,9 +52,8 @@ const Story = () => {
 	const accessToken = loginInfo.accessToken;
 	const isLogin = loginInfo.isLogin;
 	const navigate = useNavigate();
-	const [storyData, setStoryData] = useState([]);
-	const [keyword, setKeyword] = useState("");
-	const [isNoSearch, setIsNoSearch] = useState(false);
+
+	const [isFriendStory, setIsFriendStory] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
 
 	const handleLogin = () => {
@@ -78,131 +68,90 @@ const Story = () => {
 		document.body.style.overflow = "unset";
 	};
 
-	//페이지 로딩 state
-	const [page, setPage] = useState(1);
-	const [isLoading, setIsLoading] = useState(false);
-	const pageEndPoint = useRef();
-	//페이지 증가 함수
-	const addPage = () => {
-		setPage((prevPage) => {
-			return prevPage + 1;
-		});
-	};
-	//페이지 요청 함수
-	const requestPage = async (page) => {
-		let config = {};
-		let url = "";
-		if (isLogin) {
-			config = {
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
-				},
-			};
-		}
-
-		if (keyword === "") {
-			if (page === 1) setStoryData([]);
-			url = `${API_URL}/api/boards?page=${page}`;
-			await axios
-				.get(url, config)
-				.then((res) => {
-					setStoryData((prevData) => [...prevData, ...res.data.data]);
-					const totalPages = res.data.pageInfo.totalPages;
-					if (page === totalPages) {
-						setIsLoading(false);
-					} else {
-						setIsLoading(true);
-					}
-				})
-				.catch((err) => {
-					console.log(err);
-				});
-		} else {
-			url = `${API_URL}/api/boards?page=${page}&keyword=${keyword}`;
-			await axios
-				.get(url, config)
-				.then((res) => {
-					//console.log(res.data.data);
-					setStoryData(res.data.data);
-					const totalPages = res.data.pageInfo.totalPages;
-					if (page === totalPages) {
-						setIsLoading(false);
-					} else {
-						setIsLoading(true);
-					}
-				})
-				.catch((err) => {
-					// console.log(err);
-					setIsNoSearch(true);
-					setIsLoading(false);
-				});
-		}
-	};
-	//페이지 바뀔때마다 데이터 요청
-	useEffect(() => {
-		requestPage(page);
-	}, [page, keyword]);
-	//Intersection Observer로 로딩 여부 확인
-	useEffect(() => {
-		if (isLoading) {
-			//로딩시 페이지 추가
-			const observer = new IntersectionObserver(
-				(entries) => {
-					if (entries[0].isIntersecting) {
-						addPage();
-					}
-				},
-				{ threshold: 0.4 }
-			);
-			//옵저버 탐색
-			observer.observe(pageEndPoint.current);
-		}
-	}, [isLoading]);
 	//작성하기 버튼
 	const handleWriteFBtnOnClick = () => {
 		if (accessToken) {
 			navigate(`/story/storywrite`);
 		} else {
-			alert("스토리 작성은 로그인 후 이용 가능합니다.");
+			setIsOpen((prev) => !prev);
+			document.body.style.overflow = "hidden";
 		}
 	};
 
-	return (
-		<Wrap>
-			<TitleWrap>
-				<h3 className="active">모두의 스토리</h3>
-				<h3>친구의 스토리</h3>
-			</TitleWrap>
-			<SearchBar setKeyword={setKeyword} setPage={setPage} />
-			<StoryBoardWrap>
-				{keyword && isNoSearch ? <NoSearch /> : null}
-				{storyData
-					? storyData.map((el, idx) => {
-							return <StorySingle key={idx} data={el} />;
-					  })
-					: "작성된 스토리가 없습니다."}
-			</StoryBoardWrap>
-			<WriteFloatButton click={handleWriteFBtnOnClick} />
-			<Popup
-				isOpen={isOpen}
-				setIsOpen={setIsOpen}
-				title="스토리 작성"
-				content="스토리 작성은 로그인 후 이용 가능합니다."
-				button1="로그인"
-				button2="회원가입"
-				handleBtn1={handleLogin}
-				handleBtn2={handleSignup}
-			/>
-			{isLoading && (
-				<div className="loadingObserver" ref={pageEndPoint}>
-					<div></div>
-					<div></div>
-					<div></div>
-					<div></div>
-					<div></div>
-				</div>
-			)}
-		</Wrap>
-	);
+	const handleStoryTapClick = (value) => {
+		setIsFriendStory(value);
+		if (value && !isLogin) {
+			setIsOpen((prev) => !prev);
+			document.body.style.overflow = "unset";
+		}
+	};
+
+	if (isFriendStory) {
+		return (
+			<Wrap>
+				<TitleWrap>
+					<h3
+						className={isFriendStory ? "" : "active"}
+						onClick={() => handleStoryTapClick(false)}
+					>
+						모두의 스토리
+					</h3>
+					<h3
+						className={isFriendStory ? "active" : ""}
+						onClick={() => handleStoryTapClick(true)}
+					>
+						친구의 스토리
+					</h3>
+				</TitleWrap>
+				{isLogin ? (
+					<StoryFriend accessToken={accessToken} isLogin={isLogin} />
+				) : (
+					"친구 스토리는 로그인 후 볼 수 있습니다."
+				)}
+				<WriteFloatButton click={handleWriteFBtnOnClick} />
+				<Popup
+					isOpen={isOpen}
+					setIsOpen={setIsOpen}
+					title="친구 스토리 보기"
+					content="친구 스토리 보기는 로그인 후 이용 가능합니다."
+					button1="로그인"
+					button2="회원가입"
+					handleBtn1={handleLogin}
+					handleBtn2={handleSignup}
+				/>
+			</Wrap>
+		);
+	} else {
+		return (
+			<Wrap>
+				<TitleWrap>
+					<h3
+						className={isFriendStory ? "" : "active"}
+						onClick={() => handleStoryTapClick(false)}
+					>
+						모두의 스토리
+					</h3>
+					<h3
+						className={isFriendStory ? "active" : ""}
+						onClick={() => handleStoryTapClick(true)}
+					>
+						친구의 스토리
+					</h3>
+				</TitleWrap>
+				<StoryAll accessToken={accessToken} isLogin={isLogin} />
+				<WriteFloatButton click={handleWriteFBtnOnClick} />
+				<Popup
+					isOpen={isOpen}
+					setIsOpen={setIsOpen}
+					title="스토리 작성"
+					content="스토리 작성은 로그인 후 이용 가능합니다."
+					button1="로그인"
+					button2="회원가입"
+					handleBtn1={handleLogin}
+					handleBtn2={handleSignup}
+				/>
+			</Wrap>
+		);
+	}
 };
 export default Story;

--- a/client/src/pages/Story.jsx
+++ b/client/src/pages/Story.jsx
@@ -1,207 +1,208 @@
-import styled from 'styled-components';
-import SearchBar from './../components/SearchBar';
-import StorySingle from '../components/StorySingle';
-import WriteFloatButton from '../components/WriteFloatButton';
-import { useEffect, useState, useRef } from 'react';
-import axios from 'axios';
-import { API_URL } from '../data/apiUrl';
-import { useNavigate } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import Popup from '../components/Popup';
-import NoSearch from '../components/NoSearch';
+import styled from "styled-components";
+import SearchBar from "./../components/SearchBar";
+import StorySingle from "../components/StorySingle";
+import WriteFloatButton from "../components/WriteFloatButton";
+import { useEffect, useState, useRef } from "react";
+import axios from "axios";
+import { API_URL } from "../data/apiUrl";
+import { useNavigate } from "react-router-dom";
+import { useSelector } from "react-redux";
+import Popup from "../components/Popup";
+import NoSearch from "../components/NoSearch";
 
 const Wrap = styled.div`
-  .loadingObserver {
-    > div {
-      width: 100%;
-      height: 140px;
-      margin-bottom: 24px;
-      border-radius: var(--border-radius-lg);
-      background: var(--darkgrey1);
-      animation: loading_skeleton 1.2s linear infinite;
-    }
-  }
+	.loadingObserver {
+		> div {
+			width: 100%;
+			height: 140px;
+			margin-bottom: 24px;
+			border-radius: var(--border-radius-lg);
+			background: var(--darkgrey1);
+			animation: loading_skeleton 1.2s linear infinite;
+		}
+	}
 
-  @keyframes loading_skeleton {
-    0% {
-      background: var(--darkgrey1);
-    }
-    50% {
-      background: var(--darkgrey2);
-    }
-    100% {
-      background: var(--darkgrey1);
-    }
-  }
+	@keyframes loading_skeleton {
+		0% {
+			background: var(--darkgrey1);
+		}
+		50% {
+			background: var(--darkgrey2);
+		}
+		100% {
+			background: var(--darkgrey1);
+		}
+	}
 `;
 
 const TitleWrap = styled.div`
-  display: flex;
-  margin-bottom: 32px;
-  h3 {
-    margin-right: 24px;
-    letter-spacing: -0.5px;
-    font-size: var(--font-head2-size);
-  }
-  h3.active {
-    font-weight: var(--font-weight-medium);
-    color: var(--primary-color);
-  }
+	display: flex;
+	margin-bottom: 32px;
+	h3 {
+		margin-right: 24px;
+		letter-spacing: -0.5px;
+		font-size: var(--font-head2-size);
+	}
+	h3.active {
+		font-weight: var(--font-weight-medium);
+		color: var(--primary-color);
+	}
 `;
 
 const StoryBoardWrap = styled.div`
-  margin-top: 48px;
-  > div {
-    margin-bottom: 24px;
-  }
+	margin-top: 48px;
+	> div {
+		margin-bottom: 24px;
+	}
 `;
 
 const Story = () => {
-  const loginInfo = useSelector((state) => state.islogin.login);
-  const accessToken = loginInfo.accessToken;
-  const isLogin = loginInfo.isLogin;
-  const navigate = useNavigate();
-  const [storyData, setStoryData] = useState([]);
-  const [keyword, setKeyword] = useState('');
-  const [isNoSearch, setIsNoSearch] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
+	const loginInfo = useSelector((state) => state.islogin.login);
+	const accessToken = loginInfo.accessToken;
+	const isLogin = loginInfo.isLogin;
+	const navigate = useNavigate();
+	const [storyData, setStoryData] = useState([]);
+	const [keyword, setKeyword] = useState("");
+	const [isNoSearch, setIsNoSearch] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
 
-  const handleLogin = () => {
-    navigate(`/login`);
-    setIsOpen((prev) => !prev);
-    document.body.style.overflow = 'unset';
-  };
+	const handleLogin = () => {
+		navigate(`/login`);
+		setIsOpen((prev) => !prev);
+		document.body.style.overflow = "unset";
+	};
 
-  const handleSignup = () => {
-    navigate(`/signup`);
-    setIsOpen((prev) => !prev);
-    document.body.style.overflow = 'unset';
-  };
+	const handleSignup = () => {
+		navigate(`/signup`);
+		setIsOpen((prev) => !prev);
+		document.body.style.overflow = "unset";
+	};
 
-  //페이지 로딩 state
-  const [page, setPage] = useState(1);
-  const [isLoading, setIsLoading] = useState(false);
-  const pageEndPoint = useRef();
-  //페이지 증가 함수
-  const addPage = () => {
-    setPage((prevPage) => {
-      return prevPage + 1;
-    });
-  };
-  //페이지 요청 함수
-  const requestPage = async (page) => {
-    let config = {};
-    let url = '';
-    if (isLogin) {
-      config = {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      };
-    }
+	//페이지 로딩 state
+	const [page, setPage] = useState(1);
+	const [isLoading, setIsLoading] = useState(false);
+	const pageEndPoint = useRef();
+	//페이지 증가 함수
+	const addPage = () => {
+		setPage((prevPage) => {
+			return prevPage + 1;
+		});
+	};
+	//페이지 요청 함수
+	const requestPage = async (page) => {
+		let config = {};
+		let url = "";
+		if (isLogin) {
+			config = {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			};
+		}
 
-    if (keyword === '') {
-      if (page === 1) setStoryData([]);
-      url = `${API_URL}/api/boards?page=${page}`;
-      await axios
-        .get(url, config)
-        .then((res) => {
-          setStoryData((prevData) => [...prevData, ...res.data.data]);
-          const totalPages = res.data.pageInfo.totalPages;
-          if (page === totalPages) {
-            setIsLoading(false);
-          } else {
-            setIsLoading(true);
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-    } else {
-      url = `${API_URL}/api/boards?page=${page}&keyword=${keyword}`;
-      await axios
-        .get(url, config)
-        .then((res) => {
-          setStoryData(res.data.data);
-          const totalPages = res.data.pageInfo.totalPages;
-          if (page === totalPages) {
-            setIsLoading(false);
-          } else {
-            setIsLoading(true);
-          }
-        })
-        .catch((err) => {
-          setIsNoSearch(true);
-          setIsLoading(false);
-        });
-    }
-  };
-  //페이지 바뀔때마다 데이터 요청
-  useEffect(() => {
-    requestPage(page);
-  }, [page, keyword]);
-  //Intersection Observer로 로딩 여부 확인
-  useEffect(() => {
-    if (isLoading) {
-      //로딩시 페이지 추가
-      const observer = new IntersectionObserver(
-        (entries) => {
-          if (entries[0].isIntersecting) {
-            addPage();
-          }
-        },
-        { threshold: 0.4 }
-      );
-      //옵저버 탐색
-      observer.observe(pageEndPoint.current);
-    }
-  }, [isLoading]);
-  //작성하기 버튼
-  const handleWriteFBtnOnClick = () => {
-    if (accessToken) {
-      navigate(`/story/storywrite`);
-    } else {
-      setIsOpen((prev) => !prev);
-      document.body.style.overflow = 'hidden';
-    }
-  };
+		if (keyword === "") {
+			if (page === 1) setStoryData([]);
+			url = `${API_URL}/api/boards?page=${page}`;
+			await axios
+				.get(url, config)
+				.then((res) => {
+					setStoryData((prevData) => [...prevData, ...res.data.data]);
+					const totalPages = res.data.pageInfo.totalPages;
+					if (page === totalPages) {
+						setIsLoading(false);
+					} else {
+						setIsLoading(true);
+					}
+				})
+				.catch((err) => {
+					console.log(err);
+				});
+		} else {
+			url = `${API_URL}/api/boards?page=${page}&keyword=${keyword}`;
+			await axios
+				.get(url, config)
+				.then((res) => {
+					//console.log(res.data.data);
+					setStoryData(res.data.data);
+					const totalPages = res.data.pageInfo.totalPages;
+					if (page === totalPages) {
+						setIsLoading(false);
+					} else {
+						setIsLoading(true);
+					}
+				})
+				.catch((err) => {
+					// console.log(err);
+					setIsNoSearch(true);
+					setIsLoading(false);
+				});
+		}
+	};
+	//페이지 바뀔때마다 데이터 요청
+	useEffect(() => {
+		requestPage(page);
+	}, [page, keyword]);
+	//Intersection Observer로 로딩 여부 확인
+	useEffect(() => {
+		if (isLoading) {
+			//로딩시 페이지 추가
+			const observer = new IntersectionObserver(
+				(entries) => {
+					if (entries[0].isIntersecting) {
+						addPage();
+					}
+				},
+				{ threshold: 0.4 }
+			);
+			//옵저버 탐색
+			observer.observe(pageEndPoint.current);
+		}
+	}, [isLoading]);
+	//작성하기 버튼
+	const handleWriteFBtnOnClick = () => {
+		if (accessToken) {
+			navigate(`/story/storywrite`);
+		} else {
+			alert("스토리 작성은 로그인 후 이용 가능합니다.");
+		}
+	};
 
-  return (
-    <Wrap>
-      <TitleWrap>
-        <h3 className="active">모두의 스토리</h3>
-        <h3>친구의 스토리</h3>
-      </TitleWrap>
-      <SearchBar setKeyword={setKeyword} setPage={setPage} />
-      <StoryBoardWrap>
-        {keyword && isNoSearch ? <NoSearch /> : null}
-        {storyData
-          ? storyData.map((el, idx) => {
-              return <StorySingle key={idx} data={el} />;
-            })
-          : '작성된 스토리가 없습니다.'}
-      </StoryBoardWrap>
-      <WriteFloatButton click={handleWriteFBtnOnClick} />
-      <Popup
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        title="스토리 작성"
-        content="스토리 작성은 로그인 후 이용 가능합니다."
-        button1="로그인"
-        button2="회원가입"
-        handleBtn1={handleLogin}
-        handleBtn2={handleSignup}
-      />
-      {isLoading && (
-        <div className="loadingObserver" ref={pageEndPoint}>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-          <div></div>
-        </div>
-      )}
-    </Wrap>
-  );
+	return (
+		<Wrap>
+			<TitleWrap>
+				<h3 className="active">모두의 스토리</h3>
+				<h3>친구의 스토리</h3>
+			</TitleWrap>
+			<SearchBar setKeyword={setKeyword} setPage={setPage} />
+			<StoryBoardWrap>
+				{keyword && isNoSearch ? <NoSearch /> : null}
+				{storyData
+					? storyData.map((el, idx) => {
+							return <StorySingle key={idx} data={el} />;
+					  })
+					: "작성된 스토리가 없습니다."}
+			</StoryBoardWrap>
+			<WriteFloatButton click={handleWriteFBtnOnClick} />
+			<Popup
+				isOpen={isOpen}
+				setIsOpen={setIsOpen}
+				title="스토리 작성"
+				content="스토리 작성은 로그인 후 이용 가능합니다."
+				button1="로그인"
+				button2="회원가입"
+				handleBtn1={handleLogin}
+				handleBtn2={handleSignup}
+			/>
+			{isLoading && (
+				<div className="loadingObserver" ref={pageEndPoint}>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+					<div></div>
+				</div>
+			)}
+		</Wrap>
+	);
 };
 export default Story;

--- a/client/src/pages/StoryDetail.jsx
+++ b/client/src/pages/StoryDetail.jsx
@@ -1,84 +1,84 @@
-import styled from 'styled-components';
-import { useEffect, useState } from 'react';
-import HeartIcon from './../assets/heart_sprite.svg';
-import { ReactComponent as CommentIcon } from './../assets/sms.svg';
-import { useNavigate, useParams } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { API_URL } from '../data/apiUrl';
-import axios from 'axios';
-import displayedAt from '../util/displayedAt';
-import SinglePofileWrap from '../components/SingleProfileWrap';
-import StoryComments from '../components/StoryComments';
-import StoryBtn from '../components/StoryBtn';
-import StoryFileView from './../components/StoryFileView';
-import Popup from '../components/Popup';
+import styled from "styled-components";
+import { useEffect, useState } from "react";
+import HeartIcon from "./../assets/heart_sprite.svg";
+import { ReactComponent as CommentIcon } from "./../assets/sms.svg";
+import { useNavigate, useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { API_URL } from "../data/apiUrl";
+import axios from "axios";
+import displayedAt from "../util/displayedAt";
+import SinglePofileWrap from "../components/SingleProfileWrap";
+import StoryComments from "../components/StoryComments";
+import StoryBtn from "../components/StoryBtn";
+import StoryFileView from "./../components/StoryFileView";
+import Popup from "../components/Popup";
 
 const Title = styled.h4`
-  margin-top: 24px;
-  margin-bottom: 16px;
-  letter-spacing: -0.5px;
-  font-size: var(--font-head3-size);
+	margin-top: 24px;
+	margin-bottom: 16px;
+	letter-spacing: -0.5px;
+	font-size: var(--font-head3-size);
 
-  &:first-child {
-    margin-top: 0;
-  }
+	&:first-child {
+		margin-top: 0;
+	}
 `;
 
 const StoryHead = styled.div`
-  display: flex;
-  align-items: center;
-  margin-bottom: 24px;
+	display: flex;
+	align-items: center;
+	margin-bottom: 24px;
 
-  .profile_wrap {
-    flex: 1;
-    display: block;
-  }
+	.profile_wrap {
+		flex: 1;
+		display: block;
+	}
 `;
 
 const StoryLike = styled.div`
-  position: relative;
-  label {
-    box-sizing: content-box;
-    padding: 12px 16px 12px 48px;
-    background: var(--bg-color);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-btn);
-    text-align: center;
-    color: var(--strong-color);
-    cursor: pointer;
-  }
-  input[type='checkbox'] {
-    appearance: none;
-    position: absolute;
-    left: 16px;
-    top: 12px;
-    width: 24px;
-    height: 24px;
-    margin: 0;
-    background-image: url(${HeartIcon});
-    background-repeat: no-repeat;
-    background-position: 0 0;
-    cursor: pointer;
-  }
-  input[type='checkbox']:checked {
-    background-position: 0 -24px;
-  }
-  input[type='checkbox']:checked + label {
-    background: var(--border-color);
-  }
+	position: relative;
+	label {
+		box-sizing: content-box;
+		padding: 12px 16px 12px 48px;
+		background: var(--bg-color);
+		border: 1px solid var(--border-color);
+		border-radius: var(--border-radius-btn);
+		text-align: center;
+		color: var(--strong-color);
+		cursor: pointer;
+	}
+	input[type="checkbox"] {
+		appearance: none;
+		position: absolute;
+		left: 16px;
+		top: 12px;
+		width: 24px;
+		height: 24px;
+		margin: 0;
+		background-image: url(${HeartIcon});
+		background-repeat: no-repeat;
+		background-position: 0 0;
+		cursor: pointer;
+	}
+	input[type="checkbox"]:checked {
+		background-position: 0 -24px;
+	}
+	input[type="checkbox"]:checked + label {
+		background: var(--border-color);
+	}
 `;
 
 const StoryBody = styled.div`
-  .img_wrap {
-    width: 100%;
-    margin-bottom: 24px;
-    img {
-      max-width: 100%;
-    }
-  }
-  .content_wrap {
-    color: var(--strong-color);
-  }
+	.img_wrap {
+		width: 100%;
+		margin-bottom: 24px;
+		img {
+			max-width: 100%;
+		}
+	}
+	.content_wrap {
+		color: var(--strong-color);
+	}
 `;
 
 const BtnWrap = styled.div`
@@ -95,185 +95,185 @@ const BtnWrap = styled.div`
 `;
 
 const CommentsCountTag = styled.div`
-  display: flex;
-  align-items: center;
-  width: fit-content;
-  padding: 6px 12px;
-  margin: 24px 0 0 auto;
-  background: var(--border-color);
-  border-radius: var(--border-radius-btn);
-  font-size: var(--font-caption-size);
-  color: var(--strong-color);
+	display: flex;
+	align-items: center;
+	width: fit-content;
+	padding: 6px 12px;
+	margin: 24px 0 0 auto;
+	background: var(--border-color);
+	border-radius: var(--border-radius-btn);
+	font-size: var(--font-caption-size);
+	color: var(--strong-color);
 
-  svg {
-    width: 12px;
-    height: 12px;
-    margin-right: 8px;
-  }
+	svg {
+		width: 12px;
+		height: 12px;
+		margin-right: 8px;
+	}
 `;
 
 const StoryDetail = () => {
-  const navigate = useNavigate();
-  let params = useParams();
-  const loginInfo = useSelector((state) => state.islogin.login);
-  const accessToken = loginInfo.accessToken;
-  const memberId = loginInfo.memberId;
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-  const [isMe, setIsMe] = useState(false);
-  const [storyData, setStoryData] = useState({});
-  const [storyLike, setStoryLike] = useState({
-    status: false,
-    likeCount: 0,
-  });
-  useEffect(() => {
-    axios
-      .get(`${API_URL}/api/boards/${params.boardid}`, {
-        headers: {
-          //"ngrok-skip-browser-warning": "69420",
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-      .then((res) => {
-        setStoryData(res.data.data);
-        setStoryLike({
-          status: res.data.data.likeStatus,
-          likeCount: res.data.data.likeCount,
-        });
-        if (res.data.data.memberId === Number(memberId)) setIsMe(true);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  }, []);
-  let type = '';
-  if (storyData.contentType) type = storyData.contentType.split('/')[0];
+	const navigate = useNavigate();
+	let params = useParams();
+	const loginInfo = useSelector((state) => state.islogin.login);
+	const accessToken = loginInfo.accessToken;
+	const memberId = loginInfo.memberId;
+	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+	const [isMe, setIsMe] = useState(false);
+	const [storyData, setStoryData] = useState({});
+	const [storyLike, setStoryLike] = useState({
+		status: false,
+		likeCount: 0,
+	});
+	useEffect(() => {
+		axios
+			.get(`${API_URL}/api/boards/${params.boardid}`, {
+				headers: {
+					//"ngrok-skip-browser-warning": "69420",
+					Authorization: `Bearer ${accessToken}`,
+				},
+			})
+			.then((res) => {
+				setStoryData(res.data.data);
+				setStoryLike({
+					status: res.data.data.likeStatus,
+					likeCount: res.data.data.likeCount,
+				});
+				if (res.data.data.memberId === Number(memberId)) setIsMe(true);
+			})
+			.catch((err) => {
+				console.log(err);
+			});
+	}, []);
+	let type = "";
+	if (storyData.contentType) type = storyData.contentType.split("/")[0];
 
-  //스토리 좋아요
-  const handleStoryLikeClick = () => {
-    axios
-      .post(
-        `${API_URL}/api/boards/${params.boardid}/likes`,
-        {},
-        {
-          headers: {
-            Authorization: `Bearer ${loginInfo?.accessToken}`,
-          },
-        }
-      )
-      .then((res) => {
-        let countValue = 0;
-        if (res.data) countValue = 1;
-        else countValue = -1;
-        setStoryLike({
-          status: res,
-          likeCount: storyLike.likeCount + countValue,
-        });
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  };
+	//스토리 좋아요
+	const handleStoryLikeClick = () => {
+		axios
+			.post(
+				`${API_URL}/api/boards/${params.boardid}/likes`,
+				{},
+				{
+					headers: {
+						Authorization: `Bearer ${loginInfo?.accessToken}`,
+					},
+				}
+			)
+			.then((res) => {
+				let countValue = 0;
+				if (res.data) countValue = 1;
+				else countValue = -1;
+				setStoryLike({
+					status: res,
+					likeCount: storyLike.likeCount + countValue,
+				});
+			})
+			.catch((err) => {
+				console.log(err);
+			});
+	};
 
-  //수정
-  const handleStoryEditClick = () => {
-    navigate(`/story/${params.userid}/${params.boardid}/edit`);
-  };
+	//수정
+	const handleStoryEditClick = () => {
+		navigate(`/story/${params.userid}/${params.boardid}/edit`);
+	};
 
-  //삭제
-  const handleDelete = () => {
-    setIsDeleteOpen((prev) => !prev);
-    document.body.style.overflow = 'hidden';
-  };
+	//삭제
+	const handleDelete = () => {
+		setIsDeleteOpen((prev) => !prev);
+		document.body.style.overflow = "hidden";
+	};
 
-  const handleCancel = () => {
-    setIsDeleteOpen((prev) => !prev);
-    document.body.style.overflow = 'unset';
-  };
+	const handleCancel = () => {
+		setIsDeleteOpen((prev) => !prev);
+		document.body.style.overflow = "unset";
+	};
 
-  const handleStoryDeleteClick = () => {
-    axios
-      .delete(`${API_URL}/api/boards/${params.boardid}`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      })
-      .then((res) => {
-        navigate('/story');
-        document.body.style.overflow = 'unset';
-      })
-      .catch((err) => {
-        alert('스토리 삭제에 실패했습니다.');
-      });
-  };
+	const handleStoryDeleteClick = () => {
+		axios
+			.delete(`${API_URL}/api/boards/${params.boardid}`, {
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			})
+			.then((res) => {
+				navigate("/story");
+				document.body.style.overflow = "unset";
+			})
+			.catch((err) => {
+				alert("스토리 삭제에 실패했습니다.");
+			});
+	};
 
-  return (
-    <>
-      <Title>스토리</Title>
-      <div className="card big">
-        <StoryHead>
-          <a
-            href={`/profile/${params.userid}`}
-            title="유저 프로필로 이동"
-            className="profile_wrap"
-          >
-            <SinglePofileWrap
-              imgSize="big"
-              imgSrc={storyData.profileImage}
-              name={storyData.nickname}
-              subInfo={displayedAt(storyData.createdAt)}
-            />
-          </a>
-          {storyData.likeStatus !== undefined ? (
-            <StoryLike>
-              <input
-                type="checkbox"
-                id="storyLikes"
-                name="storyLikes"
-                defaultChecked={storyLike.status ? true : null}
-                onClick={handleStoryLikeClick}
-              />
-              <label htmlFor="storyLikes">{storyLike.likeCount}</label>
-            </StoryLike>
-          ) : null}
-        </StoryHead>
-        <StoryBody>
-          <StoryFileView
-            size="big"
-            fileName={storyData.uploadFileName}
-            contentType={storyData.contentType}
-          />
-          <div className="content_wrap">{storyData.content}</div>
-        </StoryBody>
-        {storyData.commentCount ? (
-          <CommentsCountTag>
-            <CommentIcon />
-            {storyData.commentCount}
-          </CommentsCountTag>
-        ) : null}
-        {isMe ? (
-          <BtnWrap>
-            <StoryBtn
-              size="big"
-              type="edit"
-              clickHandler={handleStoryEditClick}
-            />
-            <StoryBtn size="big" type="delete" clickHandler={handleDelete} />
-          </BtnWrap>
-        ) : null}
-      </div>
-      <Title>댓글</Title>
-      <StoryComments boardId={params.boardid} />
-      <Popup
-        isOpen={isDeleteOpen}
-        setIsOpen={setIsDeleteOpen}
-        title="스토리 삭제"
-        content="스토리를 삭제하시겠습니까?"
-        button1="삭제하기"
-        button2="취소"
-        handleBtn1={handleStoryDeleteClick}
-        handleBtn2={handleCancel}
-      />
-    </>
-  );
+	return (
+		<>
+			<Title>스토리</Title>
+			<div className="card big">
+				<StoryHead>
+					<a
+						href={`/profile/${params.userid}`}
+						title="유저 프로필로 이동"
+						className="profile_wrap"
+					>
+						<SinglePofileWrap
+							imgSize="big"
+							imgSrc={storyData.profileImage}
+							name={storyData.nickname}
+							subInfo={displayedAt(storyData.createdAt)}
+						/>
+					</a>
+					{storyData.likeStatus !== undefined ? (
+						<StoryLike>
+							<input
+								type="checkbox"
+								id="storyLikes"
+								name="storyLikes"
+								defaultChecked={storyLike.status ? true : null}
+								onClick={handleStoryLikeClick}
+							/>
+							<label htmlFor="storyLikes">{storyLike.likeCount}</label>
+						</StoryLike>
+					) : null}
+				</StoryHead>
+				<StoryBody>
+					<StoryFileView
+						size="big"
+						fileName={storyData.uploadFileName}
+						contentType={storyData.contentType}
+					/>
+					<div className="content_wrap">{storyData.content}</div>
+				</StoryBody>
+				{storyData.commentCount ? (
+					<CommentsCountTag>
+						<CommentIcon />
+						{storyData.commentCount}
+					</CommentsCountTag>
+				) : null}
+				{isMe ? (
+					<BtnWrap>
+						<StoryBtn
+							size="big"
+							type="edit"
+							clickHandler={handleStoryEditClick}
+						/>
+						<StoryBtn size="big" type="delete" clickHandler={handleDelete} />
+					</BtnWrap>
+				) : null}
+			</div>
+			<Title>댓글</Title>
+			<StoryComments boardId={params.boardid} />
+			<Popup
+				isOpen={isDeleteOpen}
+				setIsOpen={setIsDeleteOpen}
+				title="스토리 삭제"
+				content="스토리를 삭제하시겠습니까?"
+				button1="삭제하기"
+				button2="취소"
+				handleBtn1={handleStoryDeleteClick}
+				handleBtn2={handleCancel}
+			/>
+		</>
+	);
 };
 export default StoryDetail;


### PR DESCRIPTION
## 작업개요
- 친구 스토리 추가 (이슈번호 #207)

## worklog
- 친구 스토리 컴포넌트 분리
- 친구 스토리 보기 기능 추가
- 로그인 여부에 따라 팝업 설정
- 몇몇 팝업 에러(setIsOpen 없음) 수정
- 누락된 반응형 CSS 적용
- 모바일 뒤로가기 버튼 추가

## trouble shooting & 어려웠던 점
1. 스토리 기능 분기
제리님의 조언으로 컴포넌트를 분리하여 각각 따로 api를 요청하였습니다. 
그러니 잘 되는군요!
기존에 분기가 많았는데(모든 스토린인지,친구 스토리인지, 로그인 여부, 검색 등등...) 컴포넌트를 분리하는
로그인 여부에 따라 팝업을, 친구 있고없고의 여부에 따라 뷰 설정을 각각 다르게 잘 적용하였습니다.
2. 팝업 에러 해결
몇몇 팝업들이 setIsOpen 팝업이 없다고 콘솔에 뜨길래 기능 설정해주고 잘되는 것 확인했습니다.
어떤 기능인지 원리를 파악하는데 좀 걸렸지만, 그래도 잘 해결했습니다!
- 스토리의 경우 팝업 닫히면 콘솔 에러(setIsOpen)가 뜨고, setIsOpen 넣어주면 안 닫히길래 봤더니 
개별 스토리 안에 팝업이 들어가 있어서 background 클릭이 안되는 거였습니다. 
마크업상 개별 스토리 바깥으로 빼주니 잘 작동하였습니다!
멋대로 고쳐서 미안해요 수빈님.... 근데 제가 아무래도 프론트 마지막 작업자일 것 같아서 최종이라 생각하고 작업했어요!






























































































