### PR TITLE
[feat/fe-emailView] Email page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,55 +1,56 @@
-import styled from "styled-components";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import "./style.css";
-import Header from "./components/Header";
-import Nav from "./components/Nav";
-import Matching from "./pages/Matching";
-import MatchingDetail from "./pages/MatchingDetail";
-import MatchingWrite from "./pages/MatchingWrite";
-import MatchingEdit from "./pages/MatchingEdit";
-import Story from "./pages/Story";
-import StoryDetail from "./pages/StoryDetail";
-import StoryWrite from "./pages/StoryWrite";
-import StoryEdit from "./pages/StoryEdit";
-import Profile from "./pages/Profile";
-import ProfileEdit from "./pages/ProfileEdit";
-import BlockList from "./pages/BlockList";
-import Login from "./pages/Login";
-import Signup from "./pages/Signup";
-import Quit from "./pages/Quit";
-import GameRecommend from "./pages/GameRecommend";
-import Readme from "./pages/Readme";
-import { MOBILE_POINT } from "./data/breakpoint";
+import styled from 'styled-components';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import './style.css';
+import Header from './components/Header';
+import Nav from './components/Nav';
+import Matching from './pages/Matching';
+import MatchingDetail from './pages/MatchingDetail';
+import MatchingWrite from './pages/MatchingWrite';
+import MatchingEdit from './pages/MatchingEdit';
+import Story from './pages/Story';
+import StoryDetail from './pages/StoryDetail';
+import StoryWrite from './pages/StoryWrite';
+import StoryEdit from './pages/StoryEdit';
+import Profile from './pages/Profile';
+import ProfileEdit from './pages/ProfileEdit';
+import BlockList from './pages/BlockList';
+import Login from './pages/Login';
+import Signup from './pages/Signup';
+import Quit from './pages/Quit';
+import GameRecommend from './pages/GameRecommend';
+import Readme from './pages/Readme';
+import { MOBILE_POINT } from './data/breakpoint';
+import Email from './pages/Email';
 
 const Wrap = styled.div`
-	display: flex;
-	flex: 1;
-	width: 100%;
-	background: var(--bg-color);
+  display: flex;
+  flex: 1;
+  width: 100%;
+  background: var(--bg-color);
 `;
 
 const MainWrap = styled.section`
-	display: flex;
-	flex: 1;
-	position: relative;
-	padding: 112px 0 0 0;
-	width: calc(100% - 200px);
-	.container {
-		width: 100%;
-		max-width: 1040px;
-		padding: 0 32px;
-		margin: 48px auto 48px auto;
-	}
+  display: flex;
+  flex: 1;
+  position: relative;
+  padding: 112px 0 0 0;
+  width: calc(100% - 200px);
+  .container {
+    width: 100%;
+    max-width: 1040px;
+    padding: 0 32px;
+    margin: 48px auto 48px auto;
+  }
 
-	@media (max-width: ${MOBILE_POINT}) {
-		padding: 56px 0 56px 0;
-		width: 100%;
-		.container {
-			max-width: 100%;
-			padding: 0 16px;
-			margin: 24px auto 48px auto;
-		}
-	}
+  @media (max-width: ${MOBILE_POINT}) {
+    padding: 56px 0 56px 0;
+    width: 100%;
+    .container {
+      max-width: 100%;
+      padding: 0 16px;
+      margin: 24px auto 48px auto;
+    }
+  }
 `;
 
 const App = () => {
@@ -85,6 +86,7 @@ const App = () => {
               <Route path="/quit" element={<Quit />} />
               <Route path="/game" element={<GameRecommend />} />
               <Route path="/" element={<Readme />} />
+              <Route path="/email" element={<Email />} />
             </Routes>
           </main>
         </MainWrap>

--- a/client/src/pages/Email.jsx
+++ b/client/src/pages/Email.jsx
@@ -1,0 +1,3 @@
+const Email = () => {};
+
+export default Email;

--- a/client/src/pages/Email.jsx
+++ b/client/src/pages/Email.jsx
@@ -1,8 +1,10 @@
 import styled from 'styled-components';
 import InputWrap from '../components/InputWrap';
+import { useState } from 'react';
 
 const EmailWrap = styled.div`
-  width: 100%;
+  width: var(--col-6);
+  margin: 0 auto;
 
   p {
     margin-bottom: 24px;
@@ -29,6 +31,10 @@ const EmailInput = styled.div`
     font-size: var(--font-head2-size);
     text-align: center;
   }
+
+  .clicked {
+    background: var(--border-color);
+  }
 `;
 
 const VerifyInput = styled.div`
@@ -42,38 +48,86 @@ const VerifyInput = styled.div`
 `;
 
 const Email = () => {
+  const [isEmailError, setIsEmailError] = useState({ email: false });
+  const [isCodeError, setIsCodeError] = useState({ code: false });
+  const [isSend, setIsSend] = useState({ send: false });
+
+  const handleEmail = (e) => {
+    const emailRegex = new RegExp(
+      /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    );
+
+    setIsEmailError(
+      !e.target.value || !emailRegex.test(e.target.value)
+        ? { ...isEmailError, email: true }
+        : { ...isEmailError, email: false }
+    );
+  };
+
+  const handleCode = (e) => {
+    setIsCodeError(
+      !e.target.value
+        ? { ...isCodeError, code: true }
+        : { ...isCodeError, code: false }
+    );
+  };
+
+  const handleSend = () => {
+    setIsSend({ ...isSend, send: true });
+  };
+
   return (
     <EmailWrap className="card big">
       <EmailInput>
         <p className="verification">이메일 인증</p>
-        <div class="input_area">
+        <div className="input_area">
           <div>
             <p>이메일 입력</p>
             <InputWrap
-              className="input email"
+              className={
+                (isEmailError.email ? 'error input email' : 'input email') +
+                (isSend.send ? ' clicked' : '')
+              }
               type="text"
               name="email"
               placeholder="회원가입시 입력한 이메일을 입력하세요"
               maxLength="100"
+              onChange={handleEmail}
+              readOnly={isSend.send ? true : false}
             />
+            {isEmailError.email ? (
+              <div className="error_caption">올바른 이메일을 입력하세요.</div>
+            ) : null}
           </div>
         </div>
-        <button className="normal">인증코드 발급</button>
+        <button className="normal" onClick={handleSend}>
+          인증코드 발급
+        </button>
       </EmailInput>
-      <VerifyInput>
-        <p className="send">인증코드가 전송되었습니다.</p>
-        <div className="input_area">
-          <p>인증코드 확인</p>
-          <InputWrap
-            className="input verify"
-            type="text"
-            name="verification"
-            placeholder="인증코드를 입력하세요."
-            maxLength="50"
-          />
-        </div>
-        <button className="em">입력완료</button>
-      </VerifyInput>
+      {isSend.send && (
+        <VerifyInput>
+          <p className="send">인증코드가 전송되었습니다.</p>
+          <div className="input_area">
+            <p>인증코드 확인</p>
+            <InputWrap
+              className={
+                isCodeError.code ? 'error input verify' : 'input verify'
+              }
+              type="text"
+              name="verification"
+              placeholder="인증코드를 입력하세요."
+              maxLength="50"
+              onChange={handleCode}
+            />
+            {isCodeError.code ? (
+              <div className="error_caption">
+                입력하신 인증코드가 올바르지 않습니다.
+              </div>
+            ) : null}
+          </div>
+          <button className="em">입력완료</button>
+        </VerifyInput>
+      )}
     </EmailWrap>
   );
 };

--- a/client/src/pages/Email.jsx
+++ b/client/src/pages/Email.jsx
@@ -3,25 +3,16 @@ import InputWrap from '../components/InputWrap';
 
 const EmailWrap = styled.div`
   width: 100%;
-`;
 
-const EmailInput = styled.div`
-  width: 100%;
+  p {
+    margin-bottom: 24px;
+  }
 
-  .email_input {
+  .input_area {
     padding-bottom: 24px;
   }
 
-  .verification {
-    font-size: var(--font-head2-size);
-    text-align: center;
-  }
-
-  p {
-    margin-bottom: 16px;
-  }
-
-  .email {
+  .input {
     border-radius: 56px;
   }
 
@@ -30,16 +21,36 @@ const EmailInput = styled.div`
   }
 `;
 
+const EmailInput = styled.div`
+  width: 100%;
+  margin-bottom: 24px;
+
+  .verification {
+    font-size: var(--font-head2-size);
+    text-align: center;
+  }
+`;
+
+const VerifyInput = styled.div`
+  width: 100%;
+
+  .send {
+    color: var(--strong-color);
+    text-align: center;
+    padding: 16px 0;
+  }
+`;
+
 const Email = () => {
   return (
     <EmailWrap className="card big">
       <EmailInput>
-        <div class="email_input">
-          <p className="verification">이메일 인증</p>
+        <p className="verification">이메일 인증</p>
+        <div class="input_area">
           <div>
             <p>이메일 입력</p>
             <InputWrap
-              className="email"
+              className="input email"
               type="text"
               name="email"
               placeholder="회원가입시 입력한 이메일을 입력하세요"
@@ -49,6 +60,20 @@ const Email = () => {
         </div>
         <button className="normal">인증코드 발급</button>
       </EmailInput>
+      <VerifyInput>
+        <p className="send">인증코드가 전송되었습니다.</p>
+        <div className="input_area">
+          <p>인증코드 확인</p>
+          <InputWrap
+            className="input verify"
+            type="text"
+            name="verification"
+            placeholder="인증코드를 입력하세요."
+            maxLength="50"
+          />
+        </div>
+        <button className="em">입력완료</button>
+      </VerifyInput>
     </EmailWrap>
   );
 };

--- a/client/src/pages/Email.jsx
+++ b/client/src/pages/Email.jsx
@@ -73,7 +73,7 @@ const Email = () => {
   };
 
   const handleSend = () => {
-    setIsSend({ ...isSend, send: true });
+    if (!isEmailError) setIsSend({ ...isSend, send: true });
   };
 
   return (

--- a/client/src/pages/Email.jsx
+++ b/client/src/pages/Email.jsx
@@ -1,3 +1,56 @@
-const Email = () => {};
+import styled from 'styled-components';
+import InputWrap from '../components/InputWrap';
+
+const EmailWrap = styled.div`
+  width: 100%;
+`;
+
+const EmailInput = styled.div`
+  width: 100%;
+
+  .email_input {
+    padding-bottom: 24px;
+  }
+
+  .verification {
+    font-size: var(--font-head2-size);
+    text-align: center;
+  }
+
+  p {
+    margin-bottom: 16px;
+  }
+
+  .email {
+    border-radius: 56px;
+  }
+
+  button {
+    width: 100%;
+  }
+`;
+
+const Email = () => {
+  return (
+    <EmailWrap className="card big">
+      <EmailInput>
+        <div class="email_input">
+          <p className="verification">이메일 인증</p>
+          <div>
+            <p>이메일 입력</p>
+            <InputWrap
+              className="email"
+              type="text"
+              name="email"
+              placeholder="회원가입시 입력한 이메일을 입력하세요"
+              maxLength="100"
+            />
+          </div>
+        </div>
+        <button className="normal">인증코드 발급</button>
+      </EmailInput>
+    </EmailWrap>
+  );
+};
 
 export default Email;


### PR DESCRIPTION
## 작업개요
- Email 페이지 추가
- Email 페이지 라우터 연결

## worklog
- 인증코드 발급 전후로 렌더링 화면이 달라지게 표시했습니다.
- 이메일과 인증코드 유효성 검사는 제 임의로 작성해두었어요.

## trouble shooting & 어려웠던 점
- 4달만에 작업하는거라 까먹은 것이 너무 많았습니다..🥲 `button`에 `onClick` 속성을 줘야 하는 것을 `onChange` 속성을 주어 고전했습니다...
- 이메일 값이 들어가는 `input` 창의 경우 인증코드 발급 버튼을 누르면 입력을 막도록 설정해야하는데 그게 `readonly` 속성과 관련 있다는 것을 알았습니다! 참고로 `disabled` 속성도 입력을 막는 속성인데 이 속성의 경우 값이 `form`에 제출이 안된다고 하네요.
- `useState`를 쓰면서 그동안은 데이터 불변성에 대한 신경을 잘 쓰지 않아.. 이번에 챙겨보려고 노력했습니다.