### PR TITLE
[feat/fe-modalRefactor] Modal setting with RTK

### DIFF
--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,0 +1,95 @@
+import styled from 'styled-components';
+import { MOBILE_POINT } from '../data/breakpoint';
+import { useSelector } from 'react-redux';
+
+const Background = styled.div`
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+`;
+
+const ModalWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-left: 200px;
+  width: var(--col-6);
+
+  @media (max-width: ${MOBILE_POINT}) {
+    width: calc(100% - 32px);
+    margin: 0 auto;
+  }
+`;
+
+const Title = styled.div`
+  margin-bottom: 56px;
+
+  .title {
+    font-size: var(--font-head2-size);
+    font-weight: var(--font-weight-medium);
+  }
+`;
+
+const Content = styled.div`
+  margin-bottom: 56px;
+
+  .content {
+    text-align: center;
+    word-break: keep-all;
+    font-size: var(--font-head3-size);
+  }
+`;
+
+const ButtonWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  button {
+    width: 100%;
+    margin-right: 0px;
+
+    :last-child {
+      margin-left: 24px;
+    }
+  }
+`;
+
+const Modal = () => {
+  const { isOpen, props } = useSelector((state) => state.modal);
+
+  console.log(isOpen, props);
+
+  if (isOpen) {
+    return (
+      <Background>
+        <ModalWrap className="card big" onClick={(e) => e.stopPropagation()}>
+          <Title>
+            <div className="title">{props.title}</div>
+          </Title>
+          <Content>
+            <p className="content">{props.content}</p>
+          </Content>
+          <ButtonWrap>
+            <button className="em" onClick={props.handleBtn1}>
+              {props.button1}
+            </button>
+            {props.button2 ? (
+              <button className="normal" onClick={props.handleBtn2}>
+                {props.button2}
+              </button>
+            ) : null}
+          </ButtonWrap>
+        </ModalWrap>
+      </Background>
+    );
+  } else return null;
+};
+
+export default Modal;

--- a/client/src/hooks/useModal.jsx
+++ b/client/src/hooks/useModal.jsx
@@ -1,0 +1,18 @@
+import { useDispatch } from 'react-redux';
+import { setClose, setOpen } from '../redux/slice/modalSlice';
+
+const useModal = () => {
+  const dispatch = useDispatch();
+
+  const handleOpen = (props) => {
+    dispatch(setOpen(props));
+  };
+
+  const handleClose = () => {
+    dispatch(setClose());
+  };
+
+  return { handleOpen, handleClose };
+};
+
+export default useModal;

--- a/client/src/pages/Email.jsx
+++ b/client/src/pages/Email.jsx
@@ -21,6 +21,13 @@ const EmailWrap = styled.div`
   button {
     width: 100%;
   }
+
+  button.disabled {
+    background: var(--grey);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-btn);
+    cursor: default;
+  }
 `;
 
 const EmailInput = styled.div`
@@ -48,9 +55,10 @@ const VerifyInput = styled.div`
 `;
 
 const Email = () => {
-  const [isEmailError, setIsEmailError] = useState({ email: false });
-  const [isCodeError, setIsCodeError] = useState({ code: false });
+  const [isEmailError, setIsEmailError] = useState({ emailError: false });
+  const [isCodeError, setIsCodeError] = useState({ codeError: false });
   const [isSend, setIsSend] = useState({ send: false });
+  const [isDisabled, setIsDisabled] = useState({ disabled: false });
 
   const handleEmail = (e) => {
     const emailRegex = new RegExp(
@@ -59,21 +67,24 @@ const Email = () => {
 
     setIsEmailError(
       !e.target.value || !emailRegex.test(e.target.value)
-        ? { ...isEmailError, email: true }
-        : { ...isEmailError, email: false }
+        ? { ...isEmailError, emailError: true }
+        : { ...isEmailError, emailError: false }
     );
   };
 
   const handleCode = (e) => {
     setIsCodeError(
       !e.target.value
-        ? { ...isCodeError, code: true }
-        : { ...isCodeError, code: false }
+        ? { ...isCodeError, codeError: true }
+        : { ...isCodeError, codeError: false }
     );
   };
 
   const handleSend = () => {
-    if (!isEmailError) setIsSend({ ...isSend, send: true });
+    if (!isEmailError.emailError) {
+      setIsSend({ ...isSend, send: true });
+      setIsDisabled({ ...isDisabled, disabled: true });
+    }
   };
 
   return (
@@ -85,8 +96,9 @@ const Email = () => {
             <p>이메일 입력</p>
             <InputWrap
               className={
-                (isEmailError.email ? 'error input email' : 'input email') +
-                (isSend.send ? ' clicked' : '')
+                (isEmailError.emailError
+                  ? 'error input email'
+                  : 'input email') + (isSend.send ? ' clicked' : '')
               }
               type="text"
               name="email"
@@ -95,12 +107,16 @@ const Email = () => {
               onChange={handleEmail}
               readOnly={isSend.send ? true : false}
             />
-            {isEmailError.email ? (
+            {isEmailError.emailError ? (
               <div className="error_caption">올바른 이메일을 입력하세요.</div>
             ) : null}
           </div>
         </div>
-        <button className="normal" onClick={handleSend}>
+        <button
+          className={isDisabled.disabled ? 'disabled' : 'normal'}
+          disabled={isDisabled.disabled}
+          onClick={handleSend}
+        >
           인증코드 발급
         </button>
       </EmailInput>
@@ -111,7 +127,7 @@ const Email = () => {
             <p>인증코드 확인</p>
             <InputWrap
               className={
-                isCodeError.code ? 'error input verify' : 'input verify'
+                isCodeError.codeError ? 'error input verify' : 'input verify'
               }
               type="text"
               name="verification"
@@ -119,7 +135,7 @@ const Email = () => {
               maxLength="50"
               onChange={handleCode}
             />
-            {isCodeError.code ? (
+            {isCodeError.codeError ? (
               <div className="error_caption">
                 입력하신 인증코드가 올바르지 않습니다.
               </div>

--- a/client/src/redux/slice/modalSlice.js
+++ b/client/src/redux/slice/modalSlice.js
@@ -1,0 +1,20 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const modalSlice = createSlice({
+  name: 'modalSlice',
+  initialState: { isOpen: null, props: null },
+  reducers: {
+    setOpen: (state, action) => {
+      const { isOpen, props } = action.payload;
+      state.isOpen = isOpen;
+      state.props = props;
+    },
+    setClose: (state) => {
+      state.isOpen = null;
+      state.props = null;
+    },
+  },
+});
+
+export default modalSlice;
+export const { setOpen, setClose } = modalSlice.actions;

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -1,12 +1,13 @@
-import Logined from "./slice/loginstate";
-import { configureStore } from "@reduxjs/toolkit";
-import { persistReducer } from "redux-persist";
-import storage from "redux-persist/lib/storage";
-import { combineReducers } from "@reduxjs/toolkit";
-import GameInfo from "./slice/matchInfo";
-import UserInfo from "./slice/userInfo";
-import blockSlice from "./slice/blockSlice";
-import profileSlice from "./slice/profileSlice";
+import Logined from './slice/loginstate';
+import { configureStore } from '@reduxjs/toolkit';
+import { persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import { combineReducers } from '@reduxjs/toolkit';
+import GameInfo from './slice/matchInfo';
+import UserInfo from './slice/userInfo';
+import blockSlice from './slice/blockSlice';
+import profileSlice from './slice/profileSlice';
+import modalSlice from './slice/modalSlice';
 
 const reducer = combineReducers({
   islogin: Logined.reducer,
@@ -14,12 +15,16 @@ const reducer = combineReducers({
   userInfo: UserInfo.reducer,
   block: blockSlice.reducer,
   profile: profileSlice.reducer,
+  modal: modalSlice.reducer,
 });
+
 const persistConfig = {
-  key: "persist",
+  key: 'persist',
   storage,
 };
+
 const combineReducer = persistReducer(persistConfig, reducer);
+
 const store = configureStore({
   reducer: combineReducer,
   middleware: (getDefaultMiddleware) =>
@@ -27,4 +32,5 @@ const store = configureStore({
       serializableCheck: false,
     }),
 });
+
 export default store;


### PR DESCRIPTION
## 작업개요
- Email 페이지 로직 수정
- Modal 컴포넌트 전역 상태관리 준비

## worklog
- Email 페이지에 있던 오류를 수정했습니다. 기존에 버튼 눌러도 화면 렌더가 새로 안되던 점을 고쳤어요..
- Modal 컴포넌트를 전역 상태화하는 **준비**!를 했습니다..

## trouble shooting & 어려웠던 점
- Email 페이지에 제가 코드를 잘못 작성했더라구요. 상태값을 객체로 설정했기 때문에 `isEmailError.emailError` 이런 식으로 접근했어야 했는데 `isEmailError`로만 접근해서 렌더링이 되지 않았던 점을 수정했습니다 😅
- 로직 수정하면서 버튼 눌렀을 때 더이상 버튼 클릭하지 못하도록 `disabled` 속성도 활성화 해주었어요.

<img width="510" alt="스크린샷 2023-08-30 오후 9 49 35" src="https://github.com/codestates-seb/seb41_main_033/assets/121331811/80514c66-bd5a-4359-86ee-33f133f82dff">

- 그리고 모달을 ContextAPI를 사용해서 상태관리를 하려다가... ContextAPI는 Context를 구독하는 모든 하위 컴포넌트가 리렌더링 되는 이슈가 있다는 것을 알게 되어 기존에 사용하던 RTK를 이용해 전역 상태 관리를 해주려고 했습니다. 근데 자꾸 `initialState` 값이 제가 설정하지 않은 값으로 출력되는 오류가 있네요 ^^; 그래서 준비만 해두고 PR을 올립니다. `initialState` 이슈도 있지만, 함수 `props`가 전달이 되지 않는 문제도 있어서.. 일단은 바닐라 코드로 남겨두었습니다.